### PR TITLE
Basic API and data model

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,7 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [
+    on_exit: 1
+  ]
 ]

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -1,5 +1,105 @@
 defmodule Telemetry.Metrics do
   @moduledoc """
   Allows to collect and aggregate Telemetry events over time.
+
+  Metric is an entity transforming a stream of Telemetry events into aggregated values called
+  datapoints. A single metric may produce multiple datapoints, e.g. a counter could report a total
+  number of events it captured as well as number of events emitted during one minute long sliding
+  window.
+
+  ## Data model
+
+  Telemetry metrics provide a multi-dimensional data model. This means that a metric produces
+  multiple sets of datapoints, each set being bound to a unique set of tag values. But what does it
+  mean in practice?
+
+  Let's consider the counter metric. Imagine that you need to count a number of database queries,
+  broken down by the kind of query (`insert`, `delete` etc.) and a table the query is made against.
+  In some metric systems or libraries, you would need to define a metric for each kind of operation
+  and each table. With Telemetry, only one metric is required, and tags can be used to further break
+  down the datapoinst. Let's define such metric:
+
+      definition = Telemetry.Metrics.new(:counter, [:db, :query], tags: [:table, :kind])
+
+  In order for metric to actually work you need to register it first, but let's skip this
+  step for now. Once the metric is up and running, we can start emitting the events:
+
+      Telemetry.execute([:db, :query], 1, %{kind: :insert, table: "users"})
+      Telemetry.execute([:db, :query], 1, %{kind: :select, table: "products"})
+      Telemetry.execute([:db, :query], 1, %{kind: :select, table: "users"})
+      Telemetry.execute([:db, :query], 1, %{kind: :select, table: "users"})
+
+  And the values produced by the metric look as follows:
+
+  | `table` | `kind`  | `total`  | `window`  |
+  |---|---|---|---|
+  | "users" | "insert"  | 1 | 1 |
+  | "users" | "select" | 2 | 2 |
+  | "products" | "select" | 1 | 1 |
+
+  You can see that there is a row in the table above for each distinct set of tag values -
+  a **tagset** - and each row has values for two datapoints: `total` and `window`. Each row in the
+  table is called a **measurement**. Measurements are nothing more than values of datapoints grouped
+  by tagset.
+
+  ### Tagsets
+
+  Tagsets are derived from events used by the metric. By default, values under tag keys are taken
+  from event metadata and converted to strings, but you can also provide your own function
+  translating event metadata into a tagset.
   """
+
+  alias Telemetry.Metrics.MetricDefinition
+
+  @type metric_name :: [atom(), ...]
+  @type metric_type :: :counter
+  @type tag_key :: atom()
+  @type tag_value :: String.t()
+  @type tagset :: %{tag_key() => tag_value()}
+  @type datapoint_name :: atom()
+  @type datapoint_value :: number()
+  @type datapoints :: %{datapoint_name => datapoint_value}
+  @type measurement :: %{tagset: tagset(), datapoints: datapoints()}
+  @type option :: {:name, metric_name()} | {:tags, [tag_key()]}
+  @type options :: [option()]
+  @opaque metric_definition :: MetricDefinition.t()
+
+  ## API
+
+  @doc """
+  Returns the metric definition which can be registered in the registry.
+
+  In Telemetry, four values are required to define a metric:
+  * Type which determines what datapoints will be produced;
+  * Event whose values are to be aggregated by the metric;
+  * Name uniquely identifying the metric the scope of a single registry;
+  * Tags which are used to group datapoints
+
+  By default, the name of the metric is the name of the event and the metric is using no tags.
+  `metric_opts` are passed to the metric upon initialization.
+  """
+  @spec new(metric_type(), Telemetry.event_name(), options(), metric_options :: term()) ::
+          metric_definition()
+  def new(metric_type, event_name, opts \\ [], metric_opts \\ []) do
+    metric_name = Keyword.get(opts, :name, event_name)
+    tags = Keyword.get(opts, :tags, [])
+
+    assert_list_of_atoms!(event_name)
+    assert_list_of_atoms!(metric_name)
+    assert_list_of_atoms!(tags)
+
+    MetricDefinition.new(metric_name, metric_type, event_name, tags, metric_opts)
+  end
+
+  ## Helpers
+
+  @spec assert_list_of_atoms!(term()) :: :ok | no_return()
+  defp assert_list_of_atoms!(list) when is_list(list) do
+    Enum.all?(list, &is_atom/1) or raise ArgumentError
+    :ok
+  end
+
+  defp assert_list_of_atoms!(_) do
+    raise ArgumentError
+  end
 end

--- a/lib/telemetry_metrics/display.ex
+++ b/lib/telemetry_metrics/display.ex
@@ -1,0 +1,73 @@
+defmodule Telemetry.Metrics.Display do
+  @moduledoc """
+  Module implementing an API for displaying measurements in the console.
+  """
+
+  alias Telemetry.Metrics
+  alias Telemetry.Metrics.Registry
+
+  ## API
+
+  @spec display(Registry.registry()) :: :ok
+  def display(registry) do
+    registry
+    |> collect_measurements()
+    |> Enum.map(fn {metric_name, measurements} ->
+      format_metric_and_measurements(metric_name, measurements)
+    end)
+    |> Enum.join("\n")
+    |> IO.puts()
+  end
+
+  ## Helpers
+
+  @spec collect_measurements(Registry.registry()) :: [
+          {Metrics.metric_name(), [Metrics.measurment()]}
+        ]
+  defp collect_measurements(registry) do
+    registry
+    |> Registry.get_metric_names()
+    |> Enum.map(fn metric_name ->
+      {:ok, measurements} = Registry.collect(registry, metric_name)
+      {metric_name, measurements}
+    end)
+  end
+
+  @spec format_metric_and_measurements(Metrics.metric_name(), [Metrics.measurement()]) ::
+          String.t()
+  defp format_metric_and_measurements(metric_name, measurements) do
+    banner = """
+    ################################################################################
+    Metric #{inspect(metric_name)}
+    ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    """
+
+    formatted_measurements =
+      measurements
+      |> Enum.map(fn %{tagset: tagset, datapoints: datapoints} ->
+        formatted_tagset =
+          tagset
+          |> Enum.map(fn {tag_key, tag_value} ->
+            "#{tag_key}: #{tag_value}"
+          end)
+          |> Enum.join(", ")
+
+        formatted_datapoints =
+          datapoints
+          |> Enum.map(fn {datapoint_key, datapoint_value} ->
+            "#{datapoint_key}: #{datapoint_value}"
+          end)
+          |> Enum.join(", ")
+
+        """
+        Tagset -- #{formatted_tagset}
+        Datapoints -- #{formatted_datapoints}
+        """
+      end)
+      |> Enum.join(
+        "--------------------------------------------------------------------------------\n"
+      )
+
+    banner <> formatted_measurements
+  end
+end

--- a/lib/telemetry_metrics/metric.ex
+++ b/lib/telemetry_metrics/metric.ex
@@ -1,0 +1,30 @@
+defmodule Telemetry.Metrics.Metric do
+  @moduledoc """
+  A behaviour for various metric types.
+  """
+
+  @type state :: term()
+
+  ## Callbacks
+
+  @doc """
+  Initializes the state of the metric.
+  """
+  ## TODO: Allow to return a PID here so that metrics can be supervised.
+  @callback init(options :: term()) :: {:ok, state()} | {:error, reason :: term()}
+
+  @doc """
+  Updates measurement identified by the given tagset.
+  """
+  # NOTE: Maybe we should pass whole event metadata to metric?
+  # NOTE: Should we expect the metric to return the state here? Some metrics'
+  # state might not change on update - especially if they're backed by the process..
+  @callback update(Telemetry.event_value(), Telemetry.Metrics.tagset(), state()) :: state()
+
+  @doc """
+  Returns all measurements produced by the metric.
+
+  The set of datapoints belonging to single measurement should not be empty.
+  """
+  @callback collect(state) :: [Telemetry.Metrics.measurement()]
+end

--- a/lib/telemetry_metrics/metric/counter.ex
+++ b/lib/telemetry_metrics/metric/counter.ex
@@ -1,0 +1,36 @@
+defmodule Telemetry.Metrics.Metric.Counter do
+  @moduledoc """
+  Metric counting how many times the event has been emitted.
+
+  This metric collects only a single datapoint called `:count`.
+  """
+
+  @behaviour Telemetry.Metrics.Metric
+
+  ## WARNING: really dumb now, just to make the tests pass
+  def init(_opts) do
+    {:ok, pid} = Agent.start_link(fn -> %{} end)
+    {:ok, %{pid: pid}}
+  end
+
+  def update(_event_value, tagset, state) do
+    Agent.update(state.pid, fn values_by_tagset ->
+      Map.update(values_by_tagset, tagset, 1, &(&1 + 1))
+    end)
+
+    state
+  end
+
+  def collect(state) do
+    state.pid
+    |> Agent.get(& &1)
+    |> Enum.map(fn {tagset, value} ->
+      %{
+        tagset: tagset,
+        datapoints: %{
+          count: value
+        }
+      }
+    end)
+  end
+end

--- a/lib/telemetry_metrics/metric_definition.ex
+++ b/lib/telemetry_metrics/metric_definition.ex
@@ -1,0 +1,44 @@
+defmodule Telemetry.Metrics.MetricDefinition do
+  @moduledoc false
+  # Struct describing the metric to be registered in the registry.
+
+  alias Telemetry.Metrics.Metric.Counter
+
+  @opaque t() :: %__MODULE__{
+            metric_name: Telemetry.Metrics.metric_name(),
+            event_name: Telemetry.event_name(),
+            tags: [Telemetry.Metrics.tag_key()],
+            callback_module: module(),
+            metric_opts: term()
+          }
+
+  defstruct [:metric_name, :event_name, :tags, :callback_module, :metric_opts]
+
+  ## API
+
+  @spec new(
+          Telemetry.Metrics.metric_name(),
+          Telemetry.Metrics.metric_type(),
+          Telemetry.event_name(),
+          [Telemetry.Metrics.tag_key()],
+          metric_options :: term()
+        ) :: t()
+  def new(metric_name, metric_type, event_name, tags, metric_opts) do
+    callback_module =
+      case metric_type do
+        :counter ->
+          Counter
+
+        _ ->
+          raise ArgumentError, "Unknown metric type: #{inspect(metric_type)}"
+      end
+
+    %__MODULE__{
+      metric_name: metric_name,
+      event_name: event_name,
+      tags: tags,
+      callback_module: callback_module,
+      metric_opts: metric_opts
+    }
+  end
+end

--- a/lib/telemetry_metrics/registry.ex
+++ b/lib/telemetry_metrics/registry.ex
@@ -1,0 +1,151 @@
+defmodule Telemetry.Metrics.Registry do
+  # TODO: Consider changing a name, "Registry" will be confused with Elixir's
+  # Registry.
+  @moduledoc """
+  Instantiates and groups metrics.
+  """
+
+  use GenServer
+
+  alias Telemetry.Metrics
+
+  @type registry :: GenServer.name()
+
+  ## API
+
+  @doc """
+  Starts the registry with given name and links it to the calling process.
+  """
+  @spec start_link(registry, [Metrics.metric_definition()]) :: GenServer.on_start()
+  def start_link(registry, definitions) do
+    assert_unique_definitions!(definitions)
+    GenServer.start_link(__MODULE__, [registry, definitions], name: registry)
+  end
+
+  @doc """
+  Returns the names of all metrics registered in the registry.
+  """
+  @spec get_metric_names(registry) :: [Metrics.metric_name()]
+  def get_metric_names(registry) do
+    GenServer.call(registry, :get_metric_names)
+  end
+
+  @doc """
+  Collects and returns the measurements produced by specific metric.
+
+  Returns `{:error, :not_found}` when metric with given name is not registered.
+  """
+  @spec collect(registry, Metrics.metric_name()) ::
+          {:ok, [Metric.measurement()]} | {:error, :not_found}
+  def collect(registry, metric_name) do
+    GenServer.call(registry, {:collect, metric_name})
+  end
+
+  ## Used by event handler
+
+  # Saves the metric state after an update.
+  @spec set_metric_state(registry, Metrics.metric_name(), Metrics.Metric.state()) :: :ok
+  def set_metric_state(registry, metric_name, state) do
+    :ets.insert(state_table_name(registry), {metric_name, state})
+    :ok
+  end
+
+  # Retrieves the metric state to perform an update.
+  @spec get_metric_state(registry, Metrics.metric_name()) :: Metrics.Metric.state()
+  def get_metric_state(registry, metric_name) do
+    [{_, state}] = :ets.lookup(state_table_name(registry), metric_name)
+    state
+  end
+
+  ## GenServer callbacks
+
+  def init([registry, definitions]) do
+    initialize_state_table(registry)
+    Enum.each(definitions, fn definition -> initialize_metric(registry, definition) end)
+    state = %{registry: registry, definitions: definitions}
+    {:ok, state}
+  end
+
+  def handle_call(:get_metric_names, _from, state) do
+    metric_names = Enum.map(state.definitions, & &1.metric_name)
+    {:reply, metric_names, state}
+  end
+
+  def handle_call({:collect, metric_name}, _from, state) do
+    reply =
+      case Enum.find(state.definitions, &(&1.metric_name == metric_name)) do
+        nil ->
+          {:error, :not_found}
+
+        # TODO: Definition and state probably should be both kept in ETS.
+        definition ->
+          metric_state = get_metric_state(state.registry, metric_name)
+          measurements = definition.callback_module.collect(metric_state)
+          {:ok, measurements}
+      end
+
+    {:reply, reply, state}
+  end
+
+  ## Helpers
+
+  @spec assert_unique_definitions!([Metrics.metric_definition()]) :: :ok | no_return()
+  defp assert_unique_definitions!(definitions) do
+    definitions
+    |> Enum.group_by(& &1.metric_name, fn _ -> 1 end)
+    |> Enum.map(fn {metric_name, list} -> {metric_name, length(list)} end)
+    |> Enum.find(fn {_metric_name, occurences} -> occurences != 1 end)
+    |> case do
+      {metric_name, _occurences} ->
+        raise ArgumentError, "Metric #{inspect(metric_name)} is not unique"
+
+      nil ->
+        :ok
+    end
+  end
+
+  @spec initialize_state_table(registry) :: :ok
+  defp initialize_state_table(registry) do
+    :ets.new(state_table_name(registry), [
+      :set,
+      :public,
+      :named_table,
+      keypos: 1,
+      write_concurrency: true,
+      read_concurrency: true
+    ])
+  end
+
+  @spec state_table_name(registry) :: :ets.tab()
+  defp state_table_name(registry), do: registry
+
+  @spec initialize_metric(registry, Metrics.metric_definition()) :: :ok
+  defp initialize_metric(registry, definition) do
+    # TODO: Handle initialization failure.
+    {:ok, metric_state} = definition.callback_module.init(definition.metric_opts)
+    set_metric_state(registry, definition.metric_name, metric_state)
+    # Process name registration should in most cases guarantee uniqueness of
+    # the registry, and metric name is unique in the scope of a single registry,
+    # thus {registry, metric_name} tuple should be unique.
+    handler_id = {registry, definition.metric_name}
+
+    handler_config = %{
+      metric_name: definition.metric_name,
+      callback_module: definition.callback_module,
+      tags: definition.tags,
+      registry: registry
+    }
+
+    # TODO: Handle duplicate handler ID (rare, but might happen).
+    # Alternatively, make the IDs truly unique (but this would make them
+    # non-deterministic and undiscoverable)>
+    :ok =
+      Telemetry.attach(
+        handler_id,
+        definition.event_name,
+        Metrics.UpdateEventHandler,
+        :handle_event,
+        handler_config
+      )
+  end
+end

--- a/lib/telemetry_metrics/update_event_handler.ex
+++ b/lib/telemetry_metrics/update_event_handler.ex
@@ -1,0 +1,19 @@
+defmodule Telemetry.Metrics.UpdateEventHandler do
+  # Telemetry event handler updating the metric.
+
+  alias Telemetry.Metrics.Registry
+
+  def handle_event(_event_name, event_value, event_metadata, config) do
+    metric_state = Registry.get_metric_state(config.registry, config.metric_name)
+    # TODO: Make it more efficient.
+    # TODO: Handle string conversion failure and incomplete tagset.
+    tagset =
+      event_metadata
+      |> Map.take(config.tags)
+      |> Enum.map(fn {tag_key, value} -> {tag_key, to_string(value)} end)
+      |> Enum.into(%{})
+
+    new_metric_state = config.callback_module.update(event_value, tagset, metric_state)
+    Registry.set_metric_state(config.registry, config.metric_name, new_metric_state)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Telemetry.Metrics.MixProject do
       version: "0.1.0",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps()
     ]
   end
@@ -16,6 +17,9 @@ defmodule Telemetry.Metrics.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib/", "test/support/"]
+  defp elixirc_paths(_), do: ["lib/"]
 
   defp deps do
     [

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,25 @@
+defmodule Telemetry.Metrics.TestHelpers do
+  @moduledoc """
+  Various utility function to be used in tests.
+  """
+
+  @doc """
+  Returns a value of datapoint belonging to a measurement matching the given tagset.
+
+  Returns `nil` if a datapoint can not be found.
+  """
+  @spec find_datapoint(
+          [Telemetry.Metrics.measurement()],
+          Telemetry.Metrics.datapoint_name(),
+          Telemetry.Metrics.tagset()
+        ) :: Telemetry.Metrics.datapoint_value() | nil
+  def find_datapoint(measurements, datapoint_name, tagset) do
+    case Enum.find(measurements, &(&1.tagset == tagset)) do
+      %{datapoints: datapoints} ->
+        Map.get(datapoints, datapoint_name)
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/test/telemetry_metrics/metric/counter_test.exs
+++ b/test/telemetry_metrics/metric/counter_test.exs
@@ -1,0 +1,34 @@
+defmodule Telemetry.Metrics.Metric.CounterTest do
+  use ExUnit.Case
+
+  import Telemetry.Metrics.TestHelpers
+
+  alias Telemetry.Metrics.Metric.Counter
+
+  test "counts the number of updates grouped by tagset" do
+    {:ok, state} = Counter.init([])
+
+    Counter.update(20, %{table: "users", kind: "select"}, state)
+    Counter.update(-2, %{table: "users", kind: "select"}, state)
+    Counter.update(17, %{table: "users", kind: "insert"}, state)
+    Counter.update(30, %{table: "products", kind: "delete"}, state)
+    Counter.update(21, %{}, state)
+
+    measurements = Counter.collect(state)
+
+    assert 4 == length(measurements)
+    assert 2 == find_datapoint(measurements, :count, %{table: "users", kind: "select"})
+    assert 1 == find_datapoint(measurements, :count, %{table: "users", kind: "insert"})
+    assert 1 == find_datapoint(measurements, :count, %{table: "products", kind: "delete"})
+    assert 1 == find_datapoint(measurements, :count, %{})
+  end
+
+  test "produces a single datapoint" do
+    {:ok, state} = Counter.init([])
+
+    Counter.update(1, %{}, state)
+
+    assert [%{datapoints: datapoints}] = Counter.collect(state)
+    assert [:count] = Map.keys(datapoints)
+  end
+end

--- a/test/telemetry_metrics/registry_test.exs
+++ b/test/telemetry_metrics/registry_test.exs
@@ -1,0 +1,68 @@
+defmodule Telemetry.Metrics.RegistryTest do
+  use ExUnit.Case
+
+  alias Telemetry.Metrics
+  alias Telemetry.Metrics.Registry
+
+  setup do
+    registry = __MODULE__.TestRegistry
+
+    on_exit fn ->
+      case GenServer.whereis(registry) do
+        nil ->
+          :ok
+
+        pid ->
+          Process.exit(pid, :kill)
+      end
+    end
+
+    {:ok, registry: registry}
+  end
+
+  describe "start_link/2" do
+    test "raises when metric names are not unique", %{registry: registry} do
+      definition1 = Metrics.new(:counter, [:my, :first, :event], name: [:metric])
+      definition2 = Metrics.new(:counter, [:my, :second, :event], name: [:metric])
+
+      assert_raise ArgumentError, fn ->
+        Registry.start_link(registry, [definition1, definition2])
+      end
+    end
+  end
+
+  test "get_metric_names/1 returns the names of all registered metrics", %{registry: registry} do
+    definition1 = Metrics.new(:counter, [:my, :first, :event], name: [:first, :metric])
+    definition2 = Metrics.new(:counter, [:my, :second, :event], name: [:second, :metric])
+    definition3 = Metrics.new(:counter, [:my, :third, :event], name: [:third, :metric])
+
+    {:ok, _} = Registry.start_link(registry, [definition1, definition2, definition3])
+    metric_names = Registry.get_metric_names(registry)
+
+    assert 3 == length(metric_names)
+    assert [:first, :metric] in metric_names
+    assert [:second, :metric] in metric_names
+    assert [:third, :metric] in metric_names
+  end
+
+  describe "collect/2" do
+    test "returns error when metric with given name doesn't exist", %{registry: registry} do
+      {:ok, _} = Registry.start_link(registry, [])
+
+      assert {:error, :not_found} == Registry.collect(registry, [:metric])
+    end
+
+    test "returns datapoints produced by the metric", %{registry: registry} do
+      metric_name = [:metric]
+      metric = Metrics.new(:counter, [:my, :event], name: metric_name)
+
+      {:ok, _} = Registry.start_link(registry, [metric])
+
+      Telemetry.execute([:my, :event], 1)
+      Telemetry.execute([:my, :event], 1)
+      Telemetry.execute([:my, :event], 1)
+
+      assert {:ok, [%{tagset: %{}, datapoints: %{count: 3}}]} == Registry.collect(registry, metric_name)
+    end
+  end
+end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -1,3 +1,97 @@
 defmodule Telemetry.MetricsTest do
   use ExUnit.Case
+
+  import Telemetry.Metrics.TestHelpers
+
+  alias Telemetry.Metrics
+  alias Telemetry.Metrics.Registry
+
+  setup do
+    registry = __MODULE__.TestRegistry
+
+    on_exit fn ->
+      case GenServer.whereis(registry) do
+        nil ->
+          :ok
+
+        pid ->
+          Process.exit(pid, :kill)
+      end
+    end
+
+    {:ok, registry: registry}
+  end
+
+  test "metric value is updated", %{registry: registry} do
+    event_name = [:http, :request, :count]
+    metric_name = event_name
+
+    metrics = [
+      Metrics.new(
+        :counter,
+        event_name,
+        # by default these keys are retrieved from event metadata
+        tags: [:controller, :action]
+      )
+    ]
+
+    {:ok, _} = Registry.start_link(registry, metrics)
+
+    Telemetry.execute(event_name, 1, %{controller: "user_controller", action: "get"})
+    Telemetry.execute(event_name, 1, %{controller: "user_controller", action: "get"})
+    Telemetry.execute(event_name, 1, %{controller: "user_controller", action: "create"})
+
+    {:ok, measurements} = Registry.collect(registry, metric_name)
+
+    assert 2 == length(measurements)
+
+    assert 2 ==
+             find_datapoint(measurements, :count, %{controller: "user_controller", action: "get"})
+
+    assert 1 ==
+             find_datapoint(measurements, :count, %{
+               controller: "user_controller",
+               action: "create"
+             })
+  end
+
+  describe "new/2,3" do
+    test "raises an error on unknown metric type" do
+      assert_raise ArgumentError, fn ->
+        Metrics.new(:meter, [:http, :request, :count])
+      end
+    end
+
+    test "sets a metric name in the definition to be equal to event name by default" do
+      event_name = [:http, :request, :count]
+
+      definition = Metrics.new(:counter, event_name)
+
+      assert event_name == definition.metric_name
+    end
+
+    test "sets tags in the definition to be empty list by default" do
+      definition = Metrics.new(:counter, [:http, :request, :count])
+
+      assert [] == definition.tags
+    end
+
+    test "raises an error when metric name is not a list of atoms" do
+      assert_raise ArgumentError, fn ->
+        Metrics.new(:counter, [:http, :request, :count], name: :my_metric)
+      end
+    end
+
+    test "raises an error when event name is not a list of atoms" do
+      assert_raise ArgumentError, fn ->
+        Metrics.new(:counter, :my_event, name: [:http, :request, :count])
+      end
+    end
+
+    test "raises an error when tags is not a list of atoms" do
+      assert_raise ArgumentError, fn ->
+        Metrics.new(:counter, [:http, :request, :count], tags: :my_tag)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The goal of this PR is to discuss the basic API for defining metrics and collecting their values, but more importantly,  a data model implemented by `Telemetry.Metrics`.

## Data model

I've chosen the "multi-dimensional" data model used in InfluxDB or Prometheus. Each metric value is identified by a metric name (say, `[:http, :request, :count]`) and a set of tag values (e.g. in case of Phoenix we could have `:controller` and `:action` tags). You can imagine a counter metric which counts how many times the HTTP request event occured. Measurements aggregated by the metric could look like this:

| `controller` | `action`  | `count`  |
|---|---|---|
| "user_controller" | "create"  | 1 |
| "user_controller" | "get" | 2 |
| "product_controller" | "index" | 1 |

Additionally, for each unique set of tag values (a tagset), metric may generate multiple values (datapoints), e.g. counter could count total number of things and in the one-minute sliding window, or a summary metric could generate qunatiles, mean, maximum etc.

I think this model will work nicely for Telemetry because:
* It allows for some degree of dynamism. Event and metric names are fixed, but tags (which are derived from event metadata) can be dynamic. This is useful, for example, in case of Ecto, where we know that there will be `[:db, :query]` event, but we don't know the table or the kind of operation used upfront;
* It plays pretty well with popular metric systems. Prometheus, InfluxDB, OpenCensus, all of them support tags/labels. When it comes to systems with one-dimensional model, we can always reduce  the number of dimensions (by creating a metric name from the label values, e.g.`http_request_count_user_controller_create`), but it can't be done the other way around.

## API

The metric *definition* is created by calling `Metrics.new/2`:

```elixir
Metrics.new(:counter, [:phoenix, :controller, :call], tags: [:controller, :action], name: [:http, :request, :count])
```

> First argument is a metric type, second is event name the metric is subscribed to, metric name is optional as it defaults to event name, and you can also optionally provide the tags.

This returns a data structure which can be later registered in the *registry*. Registry (the name should be probably changed, since it will be confused with Elixir's registry) is a logical collection of metrics. You can query the registry for measurements generated by metrics. I imagine that when we have reporters, they will be given registry as the argument. We will also probably need to expose more data, such as tags used by metrics, since e.g. Prometheus reported will need to know them upfront.

And that's everything as far as regular users are concerned. There is also a `Metrics.Metric` behaviour, which can be used to implement custom metric types. I imagine it could be used in OpenCensus integration.

Last but not least, you can use `Metrics.Display.display/1` function to view awfully formatted measurements in IEx.

## Vision

With this API and data model, I imagine the integration with Ecto or Phoenix to look like this:

```elixir
def start(_, _) do
  registry = MetricRegistry
  children = [
    {Telemetry.Metrics.Registry, [registry, Phoenix.metric_definitions() ++ Ecto.metric_definitions()]},
    {TelemetryMetrics.PrometheusReporter, [registry, ...]}
  ]
end
```

And that would be it for the most basic use case. `metric_definitions/0` functions would just need to return a list of definitions returned by `Metrics.new/2,3`. The only issue I see with that solution is that both would need to (optionally) depend on `Telemetry.Metrics`.

/cc @josevalim @chrismccord @studzien