### PR TITLE
Add distribution metric specification

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -179,8 +179,6 @@ defmodule Telemetry.Metrics do
           unit: unit()
         }
 
-  @default_distribution_buckets [100, 200, 300, 400, 500]
-
   # API
 
   @doc """
@@ -276,9 +274,8 @@ defmodule Telemetry.Metrics do
   @doc """
   Returns a specification of distribution metric.
 
-  In addition to common metric options, it accepts one extra option:
-  * `:buckets` - a list distribution bucket boundaries. Defaults to
-  `#{inspect(@default_distribution_buckets)}`.
+  For a distribution metric, it is required that you include a `:buckets` field in the options
+  keyword list.
 
   See "Metric specifications" section in the top-level documentation of this module for more
   information.
@@ -297,7 +294,7 @@ defmodule Telemetry.Metrics do
     {metric_name, options} = Keyword.pop(options, :name, event_name)
     event_name = validate_event_or_metric_name!(event_name)
     metric_name = validate_event_or_metric_name!(metric_name)
-    {buckets, options} = Keyword.pop(options, :buckets, @default_distribution_buckets)
+    buckets = Keyword.fetch!(options, :buckets)
     validate_distribution_buckets!(buckets)
     validate_metric_options!(options)
     options = Keyword.merge(default_metric_options(), options)

--- a/lib/telemetry_metrics/distribution.ex
+++ b/lib/telemetry_metrics/distribution.ex
@@ -1,0 +1,34 @@
+defmodule Telemetry.Metrics.Distribution do
+  @moduledoc """
+  Defines a specification of distribution metric.
+  """
+
+  alias Telemetry.Metrics
+
+  defstruct [:name, :event_name, :metadata, :tags, :buckets, :description, :unit]
+
+  @typedoc """
+  Distribution metric bucket boundaries.
+
+  Bucket boundaries are represented by a non-empty list of increasing numbers.
+
+  ## Examples
+
+      [0, 100, 200, 300]
+      # Buckets: [-inf, 0], [0, 100], [100, 200], [200, 300], [300, +inf]
+
+      [99.9]
+      # Buckets: [-inf, 99.9], [99.9, +inf]
+  """
+  @type buckets :: [number(), ...]
+
+  @type t :: %__MODULE__{
+          name: Metrics.normalized_metric_name(),
+          event_name: Telemetry.event_name(),
+          metadata: (Telemetry.event_metadata() -> Telemetry.event_metadata()),
+          tags: Metrics.tags(),
+          buckets: buckets(),
+          description: Metrics.description(),
+          unit: Metrics.unit()
+        }
+end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -6,12 +6,17 @@ defmodule Telemetry.MetricsTest do
   alias Telemetry.Metrics
 
   # Tests common to all metric types.
-  for metric_type <- [:counter, :sum, :last_value, :distribution] do
+  for {metric_type, extra_options} <- [
+        counter: [],
+        sum: [],
+        last_value: [],
+        distribution: [buckets: [0, 100, 200]]
+      ] do
     describe "#{metric_type}/2" do
       test "raises when event name is invalid" do
         assert_raise ArgumentError, fn ->
           event_name = [:my, "event"]
-          options = []
+          options = unquote(extra_options)
           apply(Metrics, unquote(metric_type), [event_name, options])
         end
       end
@@ -19,7 +24,7 @@ defmodule Telemetry.MetricsTest do
       test "raises when metric name is invalid" do
         assert_raise ArgumentError, fn ->
           event_name = [:my, :event]
-          options = [name: ["metric"]]
+          options = [name: ["metric"]] ++ unquote(extra_options)
           apply(Metrics, unquote(metric_type), [event_name, options])
         end
       end
@@ -27,7 +32,7 @@ defmodule Telemetry.MetricsTest do
       test "raises when metadata is invalid" do
         assert_raise ArgumentError, fn ->
           event_name = [:my, :event]
-          options = [metadata: 1]
+          options = [metadata: 1] ++ unquote(extra_options)
           apply(Metrics, unquote(metric_type), [event_name, options])
         end
       end
@@ -35,7 +40,7 @@ defmodule Telemetry.MetricsTest do
       test "raises when tags are invalid" do
         assert_raise ArgumentError, fn ->
           event_name = [:my, :event]
-          options = [tags: 1]
+          options = [tags: 1] ++ unquote(extra_options)
           apply(Metrics, unquote(metric_type), [event_name, options])
         end
       end
@@ -43,7 +48,7 @@ defmodule Telemetry.MetricsTest do
       test "raises when description is invalid" do
         assert_raise ArgumentError, fn ->
           event_name = [:my, :event]
-          options = [description: :"metric description"]
+          options = [description: :"metric description"] ++ unquote(extra_options)
           apply(Metrics, unquote(metric_type), [event_name, options])
         end
       end
@@ -51,14 +56,14 @@ defmodule Telemetry.MetricsTest do
       test "raises when unit is invalid" do
         assert_raise ArgumentError, fn ->
           event_name = [:my, :event]
-          options = [unit: "second"]
+          options = [unit: "second"] ++ unquote(extra_options)
           apply(Metrics, unquote(metric_type), [event_name, options])
         end
       end
 
       test "returns #{metric_type} specification with default fields" do
         event_name = [:my, :event]
-        options = []
+        options = [] ++ unquote(extra_options)
 
         metric = apply(Metrics, unquote(metric_type), [event_name, options])
 
@@ -79,13 +84,14 @@ defmodule Telemetry.MetricsTest do
         description = "a metric"
         unit = :second
 
-        options = [
-          name: metric_name,
-          metadata: metadata,
-          tags: tags,
-          description: description,
-          unit: unit
-        ]
+        options =
+          [
+            name: metric_name,
+            metadata: metadata,
+            tags: tags,
+            description: description,
+            unit: unit
+          ] ++  unquote(extra_options)
 
         metric = apply(Metrics, unquote(metric_type), [event_name, options])
 
@@ -102,7 +108,10 @@ defmodule Telemetry.MetricsTest do
 
       test "return normalized metric and event name in the specification" do
         metric =
-          apply(Metrics, unquote(metric_type), ["http.request", [name: "http.requests.count"]])
+          apply(Metrics, unquote(metric_type), [
+            "http.request",
+            [name: "http.requests.count"] ++ unquote(extra_options)
+          ])
 
         assert [:http, :request] == metric.event_name
         assert [:http, :requests, :count] == metric.name
@@ -150,12 +159,6 @@ defmodule Telemetry.MetricsTest do
     end
   end
 
-  test "distribution/2 includes default bucket boundaries" do
-    metric = Metrics.distribution("http.requests", [])
-
-    assert [100, 200, 300, 400, 500] == metric.buckets
-  end
-
   test "distribution/2 raises if bucket boundaries are not increasing" do
     assert_raise ArgumentError, fn ->
       Metrics.distribution("http.requests", buckets: [0, 200, 100])
@@ -171,6 +174,12 @@ defmodule Telemetry.MetricsTest do
   test "distribution/2 raises if bucket boundary is not a number" do
     assert_raise ArgumentError, fn ->
       Metrics.distribution("http.requests", buckets: [0, 100, "200"])
+    end
+  end
+
+  test "distribution/2 raises if bucket boundaries are not provided" do
+    assert_raise KeyError, fn ->
+      Metrics.distribution("http.requests", [])
     end
   end
 end


### PR DESCRIPTION
This adds the missing distribution metric specification.

I have doubts about the default bucket boundaries - I'm not sure whether there should be a default value at all. 

Closes #3 