### PR TITLE
Provide the selected measurement in the metric spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 Defines data model and specifications for aggregating Telemetry events.
 
-Telemetry.Metrics provides functions for building *metric specifications* - structs describing how
+Telemetry.Metrics provides functions for building _metric specifications_ - structs describing how
 values of particular events should be aggregated. Metric specifications can be provided to a reporter
-which knows how to translate the events into a metric *in the system it reports to*. This is the crucial
+which knows how to translate the events into a metric _in the system it reports to_. This is the crucial
 part of this library design - it doesn't aggregate events itself in any way, it relies on 3rd party
 reporters to perform this work in a way that makes the most sense for a metrics system at hand.
 
@@ -17,18 +17,18 @@ would construct the following metric specification:
 
 ```elixir
 Telemetry.Metrics.counter(
-  "db.query:count",
+  "db.query.count",
   tags: [:table, :query_type]
 )
 ```
 
 This specification means that:
 
-* metric should count the number of times a `[:db, :query]` event has been emitted. `count` means
+- metric should count the number of times a `[:db, :query]` event has been emitted. `count` means
   that the metric should be based on `:count` measurement values, but it's not relevant for the
   counter metric
-* the name of the metric is `[:db, :query, :count]`
-* the count should be broken down by each unique `:table`/`:query_type` pair found in event metadata
+- the name of the metric is `[:db, :query, :count]`
+- the count should be broken down by each unique `:table`/`:query_type` pair found in event metadata
 
 Now when we provide such specification to the reporter and emit following events
 
@@ -42,7 +42,7 @@ Now when we provide such specification to the reporter and emit following events
 we expect to find the following aggregations in the metric system we report to
 
 | table      | query_type | count |
-|------------|------------|-------|
+| ---------- | ---------- | ----- |
 | `users`    | `select`   | 1     |
 | `users`    | `create`   | 1     |
 | `products` | `select`   | 2     |

--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@ would construct the following metric specification:
 
 ```elixir
 Telemetry.Metrics.counter(
-  "db.query",
-  name: "db.query.count",
+  "db.query:count",
   tags: [:table, :query_type]
 )
 ```
 
 This specification means that:
 
-* metric should count the number of times a `[:db, :query]` event has been emitted, regardless of
-  event value
+* metric should count the number of times a `[:db, :query]` event has been emitted. `count` means
+  that the metric should be based on `:count` measurement values, but it's not relevant for the
+  counter metric
 * the name of the metric is `[:db, :query, :count]`
 * the count should be broken down by each unique `:table`/`:query_type` pair found in event metadata
 
 Now when we provide such specification to the reporter and emit following events
 
 ```elixir
-:telemetry.execute([:db, :query], 32, %{table: "users", query_type: "select"})
-:telemetry.execute([:db, :query], 67, %{table: "users", query_type: "insert"})
-:telemetry.execute([:db, :query], 18, %{table: "users", query_type: "select"})
-:telemetry.execute([:db, :query], 15, %{table: "users", query_type: "select"})
+:telemetry.execute([:db, :query], %{total: 62}, %{table: "users", query_type: "select"})
+:telemetry.execute([:db, :query], %{total: 67}, %{table: "users", query_type: "insert"})
+:telemetry.execute([:db, :query], %{total: 18}, %{table: "users", query_type: "select"})
+:telemetry.execute([:db, :query], %{total: 15}, %{table: "users", query_type: "select"})
 ```
 
 we expect to find the following aggregations in the metric system we report to

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -81,17 +81,16 @@ defmodule Telemetry.Metrics do
 
   The first argument to all these functions is the metric source. Metric source may take three
   different shapes:
-  * a string representing an event name and a measurement, e.g. `"http.request:latency"`. In this
-    case, the metric is based on `[:http, :request]` events and `:latency` measurement;
-  * a string representing an event name, e.g. `"http.request"`. In this case, `:measurement` needs
-    to be provided additionally in a list of metric options;
-  * a list of atoms representing an event name, e.g. `[:http, :request]`. The same as in the previous
-    example, measaurement needs to be provided in the list of metric options.
-  are aggregated by the metric. Event name might be represented as in Telemetry, i.e. as a list of
-  atoms (`[:http, :request]`), or as a string of words joined by dots (`"http.request"`).
+
+    * a string representing an event name and a measurement, e.g. `"http.request:latency"`. In this
+      case, the metric is based on `[:http, :request]` events and `:latency` measurement;
+    * a string representing an event name, e.g. `"http.request"`. In this case, `:measurement` needs
+      to be provided additionally in a list of metric options;
+    * a list of atoms representing an event name, e.g. `[:http, :request]`. The same as in the previous
+      example, measurement needs to be provided in the list of metric options.
 
   Measurement is always required, either as a part of a metric source string or provided additionally
-  in the list of metric options. Without it it wouldn't be possible to aggregate metrics correctly,
+  in the list of metric options. Without it, it wouldn't be possible to aggregate metrics correctly,
   since Telemetry events carry multiple measurements at once (an exception here is a counter metric,
   but measurement is required for it anyway for the sake of consistency).
 

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -168,7 +168,7 @@ defmodule Telemetry.Metrics do
   """
   @type normalized_metric_name :: [atom(), ...]
 
-  @type measurement :: term() | (:telemetry.event_measurement() -> number())
+  @type measurement :: term() | (:telemetry.event_measurements() -> number())
   @type metadata ::
           :all | [key :: term()] | (:telemetry.event_metadata() -> :telemetry.event_metadata())
   @type tag :: term()

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -374,14 +374,10 @@ defmodule Telemetry.Metrics do
     segments = String.split(metric_or_event_name, ".")
 
     if Enum.any?(segments, &(&1 == "")) do
-      Logger.warn(fn ->
-        "metric or event name #{metric_or_event_name} contains leading, trailing or consecutive dots"
-      end)
+        raise ArgumentError, "metric or event name #{metric_or_event_name} contains leading, " <>
+        "trailing or consecutive dots"
     end
-
-    segments
-    |> Enum.filter(fn s -> s != "" end)
-    |> Enum.map(&String.to_atom/1)
+    Enum.map(segments, &String.to_atom/1)
   end
 
   defp validate_metric_or_event_name!(term) do

--- a/lib/telemetry_metrics/counter.ex
+++ b/lib/telemetry_metrics/counter.ex
@@ -10,7 +10,7 @@ defmodule Telemetry.Metrics.Counter do
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
-          measurement: (:telemetry.event_measurements() -> number()),
+          measurement: Metrics.measurement(),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           description: Metrics.description(),

--- a/lib/telemetry_metrics/counter.ex
+++ b/lib/telemetry_metrics/counter.ex
@@ -5,11 +5,12 @@ defmodule Telemetry.Metrics.Counter do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :metadata, :tags, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :metadata, :tags, :description, :unit]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
+          measurement: (:telemetry.event_measurements() -> number()),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           description: Metrics.description(),

--- a/lib/telemetry_metrics/distribution.ex
+++ b/lib/telemetry_metrics/distribution.ex
@@ -5,7 +5,7 @@ defmodule Telemetry.Metrics.Distribution do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :metadata, :tags, :buckets, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :metadata, :tags, :buckets, :description, :unit]
 
   @typedoc """
   Distribution metric bucket boundaries.
@@ -25,6 +25,7 @@ defmodule Telemetry.Metrics.Distribution do
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
+          measurement: (:telemetry.event_measurements() -> number()),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           buckets: buckets(),

--- a/lib/telemetry_metrics/distribution.ex
+++ b/lib/telemetry_metrics/distribution.ex
@@ -25,7 +25,7 @@ defmodule Telemetry.Metrics.Distribution do
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
-          measurement: (:telemetry.event_measurements() -> number()),
+          measurement: Metrics.measurement(),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           buckets: buckets(),

--- a/lib/telemetry_metrics/last_value.ex
+++ b/lib/telemetry_metrics/last_value.ex
@@ -5,11 +5,12 @@ defmodule Telemetry.Metrics.LastValue do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :metadata, :tags, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :metadata, :tags, :description, :unit]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
+          measurement: (:telemetry.event_measurements() -> number()),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           description: Metrics.description(),

--- a/lib/telemetry_metrics/last_value.ex
+++ b/lib/telemetry_metrics/last_value.ex
@@ -10,7 +10,7 @@ defmodule Telemetry.Metrics.LastValue do
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
-          measurement: (:telemetry.event_measurements() -> number()),
+          measurement: Metrics.measurement(),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           description: Metrics.description(),

--- a/lib/telemetry_metrics/sum.ex
+++ b/lib/telemetry_metrics/sum.ex
@@ -5,11 +5,12 @@ defmodule Telemetry.Metrics.Sum do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :metadata, :tags, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :metadata, :tags, :description, :unit]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
+          measurement: (:telemetry.event_measurements() -> number()),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           description: Metrics.description(),

--- a/lib/telemetry_metrics/sum.ex
+++ b/lib/telemetry_metrics/sum.ex
@@ -10,7 +10,7 @@ defmodule Telemetry.Metrics.Sum do
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
-          measurement: (:telemetry.event_measurements() -> number()),
+          measurement: Metrics.measurement(),
           metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
           description: Metrics.description(),

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,15 @@ defmodule Telemetry.Metrics.MixProject do
     ]
   end
 
+  # Measurement nie musi być dla kazdego
+  # - counter - nie potrzebuje
+  # - gauge - potrzebuje
+  # - distribution - potrzebuje
+  # - sum - potrzebuje
+  #
+  # Ale ze względu na to, ze to jest common case, to powinnismy wspierac
+  # to w tej skladni skroconej. A reportery powinny zakładać, 
+
   def application do
     [
       extra_applications: [:logger]
@@ -34,7 +43,7 @@ defmodule Telemetry.Metrics.MixProject do
 
   defp deps do
     [
-      {:telemetry, "~> 0.3"},
+      {:telemetry, "~> 0.4"},
       {:ex_doc, "~> 0.19.0", only: :docs},
       {:dialyxir, "~> 1.0.0-rc.3", only: :test, runtime: false},
       {:excoveralls, "~> 0.10.0", only: :test, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -18,15 +18,6 @@ defmodule Telemetry.Metrics.MixProject do
     ]
   end
 
-  # Measurement nie musi być dla kazdego
-  # - counter - nie potrzebuje
-  # - gauge - potrzebuje
-  # - distribution - potrzebuje
-  # - sum - potrzebuje
-  #
-  # Ale ze względu na to, ze to jest common case, to powinnismy wspierac
-  # to w tej skladni skroconej. A reportery powinny zakładać, 
-
   def application do
     [
       extra_applications: [:logger]

--- a/mix.lock
+++ b/mix.lock
@@ -15,6 +15,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
-  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -1,8 +1,6 @@
 defmodule Telemetry.MetricsTest do
   use ExUnit.Case
 
-  import ExUnit.CaptureLog
-
   alias Telemetry.Metrics
 
   # Tests common to all metric types.
@@ -158,25 +156,25 @@ defmodule Telemetry.MetricsTest do
         assert %{constant: "metadata"} == metadata_fun.(event_metadata)
       end
 
-      test "using metric name with leading, trailing or subsequent dots logs a warning" do
+      test "using metric name with leading, trailing or subsequent dots raises" do
         for name <- [".metric.name", "metric.name.", "metric..name"] do
-          assert capture_log(fn ->
+          assert_raise ArgumentError, fn ->
                    apply(Metrics, unquote(metric_type), [
                      name,
                      unquote(extra_options)
                    ])
-                 end) =~ "metric or event name #{name} contains"
+                 end
         end
       end
 
-      test "using event name with leading, trailing or subsequent dots in event name logs a warning" do
+      test "using event name with leading, trailing or subsequent dots raises" do
         for event_name <- [".event.value", "event.value.", "event..name"] do
-          assert capture_log(fn ->
+          assert_raise ArgumentError, fn ->
                    apply(Metrics, unquote(metric_type), [
                      "my.metric",
                      [event_name: event_name] ++ unquote(extra_options)
                    ])
-                 end) =~ "metric or event name #{event_name} contains"
+                 end
         end
       end
 

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -13,72 +13,83 @@ defmodule Telemetry.MetricsTest do
         distribution: [buckets: [0, 100, 200]]
       ] do
     describe "#{metric_type}/2" do
-      test "raises when event name is invalid" do
-        assert_raise ArgumentError, fn ->
-          event_name = [:my, "event"]
-          options = unquote(extra_options)
-          apply(Metrics, unquote(metric_type), [event_name, options])
+      test "raises when metric source is invalid" do
+        for source <- [
+              [:my, "event"],
+              ":",
+              "my.event:",
+              ":measurement",
+              "::",
+              "my:beautiful:event"
+            ] do
+          assert_raise ArgumentError, fn ->
+            options = unquote(extra_options)
+            apply(Metrics, unquote(metric_type), [source, options])
+          end
         end
       end
 
       test "raises when metric name is invalid" do
         assert_raise ArgumentError, fn ->
-          event_name = [:my, :event]
+          source = [:my, :event]
           options = [name: ["metric"]] ++ unquote(extra_options)
-          apply(Metrics, unquote(metric_type), [event_name, options])
+          apply(Metrics, unquote(metric_type), [source, options])
         end
       end
 
       test "raises when metadata is invalid" do
         assert_raise ArgumentError, fn ->
-          event_name = [:my, :event]
+          source = [:my, :event]
           options = [metadata: 1] ++ unquote(extra_options)
-          apply(Metrics, unquote(metric_type), [event_name, options])
+          apply(Metrics, unquote(metric_type), [source, options])
         end
       end
 
       test "raises when tags are invalid" do
         assert_raise ArgumentError, fn ->
-          event_name = [:my, :event]
+          source = [:my, :event]
           options = [tags: 1] ++ unquote(extra_options)
-          apply(Metrics, unquote(metric_type), [event_name, options])
+          apply(Metrics, unquote(metric_type), [source, options])
         end
       end
 
       test "raises when description is invalid" do
         assert_raise ArgumentError, fn ->
-          event_name = [:my, :event]
+          source = [:my, :event]
           options = [description: :"metric description"] ++ unquote(extra_options)
-          apply(Metrics, unquote(metric_type), [event_name, options])
+          apply(Metrics, unquote(metric_type), [source, options])
         end
       end
 
       test "raises when unit is invalid" do
         assert_raise ArgumentError, fn ->
-          event_name = [:my, :event]
+          source = [:my, :event]
           options = [unit: "second"] ++ unquote(extra_options)
-          apply(Metrics, unquote(metric_type), [event_name, options])
+          apply(Metrics, unquote(metric_type), [source, options])
         end
       end
 
       test "returns #{metric_type} specification with default fields" do
-        event_name = [:my, :event]
+        source = "my.event:value"
         options = [] ++ unquote(extra_options)
 
-        metric = apply(Metrics, unquote(metric_type), [event_name, options])
+        metric = apply(Metrics, unquote(metric_type), [source, options])
 
-        assert event_name = metric.event_name
-        assert event_name == metric.name
+        assert [:my, :event] == metric.event_name
+        assert [:my, :event, :value] == metric.name
         assert [] == metric.tags
         assert nil == metric.description
         assert :unit == metric.unit
         metadata_fun = metric.metadata
         assert %{} == metadata_fun.(%{key: 1, another_key: 2})
+        measurement_fun = metric.measurement
+        assert 3 == measurement_fun.(%{value: 3, other_value: 2})
       end
 
       test "returns #{metric_type} specification with overriden fields" do
-        event_name = [:my, :event]
+        source = "my.event:value"
         metric_name = [:metric]
+        measurement = :other_value
         metadata = ["action"]
         tags = [:controller, "action"]
         description = "a metric"
@@ -87,29 +98,33 @@ defmodule Telemetry.MetricsTest do
         options =
           [
             name: metric_name,
+            measurement: measurement,
             metadata: metadata,
             tags: tags,
             description: description,
             unit: unit
           ] ++ unquote(extra_options)
 
-        metric = apply(Metrics, unquote(metric_type), [event_name, options])
+        metric = apply(Metrics, unquote(metric_type), [source, options])
 
-        assert event_name == metric.event_name
+        assert [:my, :event] == metric.event_name
         assert metric_name == metric.name
         assert tags == metric.tags
         assert description == metric.description
         assert unit == metric.unit
         metadata_fun = metric.metadata
+        measurement_fun = metric.measurement
 
         assert %{"action" => "create"} ==
                  metadata_fun.(%{:controller => UserController, "action" => "create"})
+
+        assert 2 == measurement_fun.(%{value: 3, other_value: 2})
       end
 
       test "return normalized metric and event name in the specification" do
         metric =
           apply(Metrics, unquote(metric_type), [
-            "http.request",
+            "http.request:latency",
             [name: "http.requests.count"] ++ unquote(extra_options)
           ])
 
@@ -120,7 +135,7 @@ defmodule Telemetry.MetricsTest do
       test "setting :all as metadata returns identity function in metric spec" do
         metric =
           apply(Metrics, unquote(metric_type), [
-            [:my, :event],
+            "my.event:value",
             [metadata: :all] ++ unquote(extra_options)
           ])
 
@@ -133,7 +148,7 @@ defmodule Telemetry.MetricsTest do
       test "setting list of terms as metadata returns function returning subset of a map in metric spec" do
         metric =
           apply(Metrics, unquote(metric_type), [
-            [:my, :event],
+            "my.event:value",
             [metadata: [:action]] ++ unquote(extra_options)
           ])
 
@@ -146,7 +161,7 @@ defmodule Telemetry.MetricsTest do
       test "setting function as metadata returns that function in metric spec" do
         metric =
           apply(Metrics, unquote(metric_type), [
-            [:my, :event],
+            "my.event:value",
             [metadata: fn _ -> %{constant: "metadata"} end] ++ unquote(extra_options)
           ])
 
@@ -156,25 +171,27 @@ defmodule Telemetry.MetricsTest do
         assert %{constant: "metadata"} == metadata_fun.(event_metadata)
       end
 
-      test "setting metric name with leading, trailing or subsequent dots logs a warning" do
+      test "using metric name with leading, trailing or subsequent dots logs a warning" do
         for metric_name <- [".metric", "metric.", "metric..name"] do
           assert capture_log(fn ->
                    apply(Metrics, unquote(metric_type), [
                      [:my, :event],
-                     [name: metric_name] ++ unquote(extra_options)
+                     [name: metric_name, measurement: :value] ++ unquote(extra_options)
                    ])
-                 end) =~ "Event or metric name #{metric_name} contains"
+                 end) =~ "metric name #{metric_name} contains"
         end
       end
 
-      test "setting event name with leading, trailing or subsequent dots logs a warning" do
-        for event_name <- [".event", "event.", "event..name"] do
+      test "using metric source with leading, trailing or subsequent dots in event name logs a warning" do
+        for source <- [".event:value", "event.:value", "event..name"] do
+          [event_name | _] = String.split(source, ":")
+
           assert capture_log(fn ->
                    apply(Metrics, unquote(metric_type), [
-                     event_name,
-                     [name: [:my, :metric]] ++ unquote(extra_options)
+                     source,
+                     [name: [:my, :metric], measurement: :value] ++ unquote(extra_options)
                    ])
-                 end) =~ "Event or metric name #{event_name} contains"
+                 end) =~ "event name #{event_name} contains"
         end
       end
 
@@ -183,7 +200,7 @@ defmodule Telemetry.MetricsTest do
 
         metric =
           apply(Metrics, unquote(metric_type), [
-            [:my, :event],
+            "my.event:value",
             [tags: tags] ++ unquote(extra_options)
           ])
 
@@ -197,37 +214,123 @@ defmodule Telemetry.MetricsTest do
 
         metric =
           apply(Metrics, unquote(metric_type), [
-            [:my, :event],
+            "my.event:value",
             [tags: tags, metadata: metadata] ++ unquote(extra_options)
           ])
 
         event_metadata = metric.metadata.(%{controller: UserController, action: :create})
         refute tags == Map.keys(event_metadata)
       end
+
+      test "setting term as measurement returns function returning value under that term in metric spec" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            [:my, :event],
+            [measurement: :value] ++ unquote(extra_options)
+          ])
+
+        measurement_fun = metric.measurement
+        event_measurements = %{value: 3, other_value: 2}
+
+        assert 3 == measurement_fun.(event_measurements)
+      end
+
+      test "setting function as measurement returns that function in metric spec" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            [:my, :event],
+            [measurement: fn _ -> 42 end] ++ unquote(extra_options)
+          ])
+
+        measurement_fun = metric.measurement
+        event_measurements = %{value: 3, other_value: 2}
+
+        assert 42 == measurement_fun.(event_measurements)
+      end
+
+      test "metric source can be just an event name as list of atoms" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            [:my, :event],
+            [measurement: :value] ++ unquote(extra_options)
+          ])
+
+        assert [:my, :event] == metric.event_name
+        assert [:my, :event] == metric.name
+        measurement_fun = metric.measurement
+        event_measurements = %{value: 3, other_value: 2}
+        assert 3 == measurement_fun.(event_measurements)
+      end
+
+      test "metric source can be just an event name as string" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "my.event",
+            [measurement: :value] ++ unquote(extra_options)
+          ])
+
+        assert [:my, :event] == metric.event_name
+        assert [:my, :event] == metric.name
+        measurement_fun = metric.measurement
+        event_measurements = %{value: 3, other_value: 2}
+        assert 3 == measurement_fun.(event_measurements)
+      end
+
+      test "metric source can be an event name and measurement as string" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "my.event:value",
+            unquote(extra_options)
+          ])
+
+        assert [:my, :event] == metric.event_name
+        assert [:my, :event, :value] == metric.name
+        measurement_fun = metric.measurement
+        event_measurements = %{value: 3, other_value: 2}
+        assert 3 == measurement_fun.(event_measurements)
+      end
+
+      test "measurement is required" do
+        assert_raise ArgumentError, fn ->
+          apply(Metrics, unquote(metric_type), [
+            "my.event",
+            unquote(extra_options)
+          ])
+        end
+      end
+
+      test "measurement function returns 0 if there is no measurement under given key" do
+          metric = apply(Metrics, unquote(metric_type), [
+            "my.event:value",
+            unquote(extra_options)
+          ])
+
+          assert 0 == metric.measurement.(%{other_value: 2})
+      end
     end
   end
 
   test "distribution/2 raises if bucket boundaries are not increasing" do
     assert_raise ArgumentError, fn ->
-      Metrics.distribution("http.requests", buckets: [0, 200, 100])
+      Metrics.distribution("http.request:latency", buckets: [0, 200, 100])
     end
   end
 
   test "distribution/2 raises if bucket boundaries are empty" do
     assert_raise ArgumentError, fn ->
-      Metrics.distribution("http.requests", buckets: [])
+      Metrics.distribution("http.request:latency", buckets: [])
     end
   end
 
   test "distribution/2 raises if bucket boundary is not a number" do
     assert_raise ArgumentError, fn ->
-      Metrics.distribution("http.requests", buckets: [0, 100, "200"])
+      Metrics.distribution("http.request:latency", buckets: [0, 100, "200"])
     end
   end
 
   test "distribution/2 raises if bucket boundaries are not provided" do
     assert_raise KeyError, fn ->
-      Metrics.distribution("http.requests", [])
+      Metrics.distribution("http.request:latency", [])
     end
   end
 end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -65,10 +65,9 @@ defmodule Telemetry.MetricsTest do
         assert [] == metric.tags
         assert nil == metric.description
         assert :unit == metric.unit
+        assert :latency = metric.measurement
         metadata_fun = metric.metadata
         assert %{} == metadata_fun.(%{key: 1, another_key: 2})
-        measurement_fun = metric.measurement
-        assert 3 == measurement_fun.(%{latency: 3, other_value: 2})
       end
 
       test "returns #{metric_type} specification with overriden fields" do
@@ -97,13 +96,10 @@ defmodule Telemetry.MetricsTest do
         assert tags == metric.tags
         assert description == metric.description
         assert unit == metric.unit
+        assert :other_value = metric.measurement
         metadata_fun = metric.metadata
-        measurement_fun = metric.measurement
-
         assert %{"action" => "create"} ==
                  metadata_fun.(%{:controller => UserController, "action" => "create"})
-
-        assert 2 == measurement_fun.(%{value: 3, other_value: 2})
       end
 
       test "return normalized metric and event name in the specification" do
@@ -159,22 +155,22 @@ defmodule Telemetry.MetricsTest do
       test "using metric name with leading, trailing or subsequent dots raises" do
         for name <- [".metric.name", "metric.name.", "metric..name"] do
           assert_raise ArgumentError, fn ->
-                   apply(Metrics, unquote(metric_type), [
-                     name,
-                     unquote(extra_options)
-                   ])
-                 end
+            apply(Metrics, unquote(metric_type), [
+              name,
+              unquote(extra_options)
+            ])
+          end
         end
       end
 
       test "using event name with leading, trailing or subsequent dots raises" do
         for event_name <- [".event.value", "event.value.", "event..name"] do
           assert_raise ArgumentError, fn ->
-                   apply(Metrics, unquote(metric_type), [
-                     "my.metric",
-                     [event_name: event_name] ++ unquote(extra_options)
-                   ])
-                 end
+            apply(Metrics, unquote(metric_type), [
+              "my.metric",
+              [event_name: event_name] ++ unquote(extra_options)
+            ])
+          end
         end
       end
 
@@ -212,10 +208,7 @@ defmodule Telemetry.MetricsTest do
             [measurement: :value] ++ unquote(extra_options)
           ])
 
-        measurement_fun = metric.measurement
-        event_measurements = %{value: 3, other_value: 2}
-
-        assert 3 == measurement_fun.(event_measurements)
+        assert :value == metric.measurement
       end
 
       test "setting function as measurement returns that function in metric spec" do
@@ -240,9 +233,7 @@ defmodule Telemetry.MetricsTest do
 
         assert [:my, :event, :value] == metric.name
         assert [:my, :event] == metric.event_name
-        measurement_fun = metric.measurement
-        event_measurements = %{value: 3, other_value: 2}
-        assert 3 == measurement_fun.(event_measurements)
+        assert :value == metric.measurement
       end
 
       test "metric name can be a string" do
@@ -254,9 +245,7 @@ defmodule Telemetry.MetricsTest do
 
         assert [:my, :event, :value] == metric.name
         assert [:my, :event] == metric.event_name
-        measurement_fun = metric.measurement
-        event_measurements = %{value: 3, other_value: 2}
-        assert 3 == measurement_fun.(event_measurements)
+        assert :value = metric.measurement
       end
 
       test "raises when metric name is empty" do


### PR DESCRIPTION
This PR upgrades the library to use Telemetry 0.4. This means that users need to choose which event measurement the metric values are based on. There are two ways to achieve this:

* by providing measurement in the first argument to a metric function, i.e. a metric *source*:

```elixir
counter("http.request:count") # for counter the measurement might not exist, it doesn't matter
last_value("vm.memory:total")
distribution("http.request:latency")
```

* by providing it explicitly as a metric option 

```elixir
distribution("http.request", measurement: :latency)
distribution("http.request", measurement: fn m -> Map.fetch!(m, :latency) end)
```

There is a new `:measurement` key in the metric spec containing the function which can be applied to event measurements and returns a value of the selected measurement (if the measurement is not present it returns 0).

Another change is that now by default metric name is based on the whole metric source and not only the event name. For example, `"http.request:latency"` metric source gives `[:http, :request, :latency]` metric name, and `"http.request"` metric source gives `[:http, :request]` name. The name can be still overridden using the `:name` option.

Closes #21 