### PR TITLE
Clarify behavior of :tags and :metadata options on metadata function

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -232,7 +232,7 @@ defmodule Telemetry.Metrics do
       event_name: event_name,
       measurement: measurement,
       tags: Keyword.fetch!(options, :tags),
-      tag_values: options |> Keyword.fetch!(:tag_values) |> tag_values_spec_to_function(),
+      tag_values: options |> Keyword.fetch!(:tag_values),
       description: Keyword.fetch!(options, :description),
       unit: Keyword.fetch!(options, :unit)
     }
@@ -268,7 +268,7 @@ defmodule Telemetry.Metrics do
       event_name: event_name,
       measurement: measurement,
       tags: Keyword.fetch!(options, :tags),
-      tag_values: options |> Keyword.fetch!(:tag_values) |> tag_values_spec_to_function(),
+      tag_values: options |> Keyword.fetch!(:tag_values),
       description: Keyword.fetch!(options, :description),
       unit: Keyword.fetch!(options, :unit)
     }
@@ -302,7 +302,7 @@ defmodule Telemetry.Metrics do
       event_name: event_name,
       measurement: measurement,
       tags: Keyword.fetch!(options, :tags),
-      tag_values: options |> Keyword.fetch!(:tag_values) |> tag_values_spec_to_function(),
+      tag_values: options |> Keyword.fetch!(:tag_values),
       description: Keyword.fetch!(options, :description),
       unit: Keyword.fetch!(options, :unit)
     }
@@ -342,7 +342,7 @@ defmodule Telemetry.Metrics do
       event_name: event_name,
       measurement: measurement,
       tags: Keyword.fetch!(options, :tags),
-      tag_values: options |> Keyword.fetch!(:tag_values) |> tag_values_spec_to_function(),
+      tag_values: options |> Keyword.fetch!(:tag_values),
       buckets: buckets,
       description: Keyword.fetch!(options, :description),
       unit: Keyword.fetch!(options, :unit)
@@ -462,8 +462,4 @@ defmodule Telemetry.Metrics do
   defp validate_distribution_buckets!(term) do
     raise ArgumentError, "expected buckets to be a non-empty list, got #{inspect(term)}"
   end
-
-  @spec tag_values_spec_to_function(tag_values()) ::
-          (:telemetry.event_metadata() -> :telemetry.event_metadata())
-  defp tag_values_spec_to_function(fun), do: fun
 end

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -98,9 +98,8 @@ defmodule Telemetry.Metrics do
       the last segment of the metric name. It can be either an arbitrary term, a key in the event's
       measurements map, or a function accepting the whole measurements map and returning the actual
       value to be used.
-      * `:tags` - a subset of metadata keys by which aggregations will be broken down. If `:tags`
-      are set but `:metadata` isn't, then `:metadata` is set to the same value as `:tags` for
-      convenience. Defaults to an empty list.
+    * `:tags` - a subset of metadata keys by which aggregations will be broken down. Defaults to
+      an empty list.
     * `:tag_values` - a function that receives the metadata and returns a map with the tags as keys
       and their respective values. Defaults to returning the metadata itself.
     * `:description` - human-readable description of the metric. Might be used by reporters for

--- a/lib/telemetry_metrics/counter.ex
+++ b/lib/telemetry_metrics/counter.ex
@@ -5,14 +5,14 @@ defmodule Telemetry.Metrics.Counter do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :metadata, :tags, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
-          metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
+          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: Metrics.description(),
           unit: Metrics.unit()
         }

--- a/lib/telemetry_metrics/distribution.ex
+++ b/lib/telemetry_metrics/distribution.ex
@@ -5,7 +5,7 @@ defmodule Telemetry.Metrics.Distribution do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :metadata, :tags, :buckets, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :buckets, :description, :unit]
 
   @typedoc """
   Distribution metric bucket boundaries.
@@ -26,8 +26,8 @@ defmodule Telemetry.Metrics.Distribution do
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
-          metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
+          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           buckets: buckets(),
           description: Metrics.description(),
           unit: Metrics.unit()

--- a/lib/telemetry_metrics/last_value.ex
+++ b/lib/telemetry_metrics/last_value.ex
@@ -5,14 +5,14 @@ defmodule Telemetry.Metrics.LastValue do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :metadata, :tags, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
-          metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
+          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: Metrics.description(),
           unit: Metrics.unit()
         }

--- a/lib/telemetry_metrics/sum.ex
+++ b/lib/telemetry_metrics/sum.ex
@@ -5,14 +5,14 @@ defmodule Telemetry.Metrics.Sum do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :metadata, :tags, :description, :unit]
+  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
-          metadata: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           tags: Metrics.tags(),
+          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: Metrics.description(),
           unit: Metrics.unit()
         }


### PR DESCRIPTION
This is an attempt at updating the docs to try to clarify the resulting behavior of the returned metadata function when `:tags` and `:metadata` are both set.

I found myself confused while working on handling aggregation with the map returned by passing the event metadata to the metadata function when both were set with different keys or `:metadata` was set to all or a function that returned a map with different keys (for instance - changing `:repo` to `:db` in a function). Since I would use the resulting map to identify unique time series to report, I feel users would be equally confused about how setting each option affects which `tag:value` results are produced in the end.

I couldn't think of a code change that would alleviate this aside from unifying the behavior under just the tags option and eliminating metadata as an option altogether. The more I work with it, the more I think an API change may be warranted here. If we want to have a broader discussion on a possible API change, I will create an issue.