### PR TITLE
Restructure documentation and add a guide on writing reporters

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,160 @@
+# Overview
+
+Telemetry.Metrics provides a common interface for defining metrics based on
+[`:telemetry`](https://github.com/beam-telemetry/telemetry) events. While a single event means that
+_a thing_ happened (e.g. an HTTP request was sent or a DB query returned a result), a metric
+is an aggregation of those events over time. For instance, we could count the number of HTTP
+requests, or keep track of the sum of payload sizes returned by DB queries.
+
+To give a more concrete example, imagine that somewhere in your code you have a function which sends
+an HTTP request, measures the time it took to get a response, and emits an event with the information:
+
+```elixir
+:telemetry.execute([:http, :request, :done], %{duration: duration})
+```
+
+You could define a counter metric, which counts how many HTTP requests were completed:
+
+```elixir
+Telemetry.Metrics.counter("http.request.done.count")
+```
+
+or you could use a distribution metric to see how many queries were completed in particular time
+buckets:
+
+```elixir
+Telemetry.Metrics.distribution("http.request.done.duration", buckets: [100, 200, 300])
+```
+
+> There are a couple more metric types, and they are all described in detail in the "Metric types"
+> section.
+
+Because of the fact that metrics are based only on events being emitted, you can easily create
+metrics from events published by the libraries you're using in your project. But metric definitions
+on their own are not enough - aggregated metrics need to be sent somewhere, so that you can inspect
+how your system behaves - and that's what reporters are for.
+
+## Reporters
+
+Reporters are responsible for publishing metrics to some system where they can be inspected. For
+example, there could be a reporter pushing metrics to StatsD, some time-series database, or exposing
+a HTTP endpoint for Prometheus to scrape.
+
+Under the hood, reporter needs to attach event handlers to relevant events and extract specific
+measurement. This information is included in the metric definitions.
+
+Note that Telemetry.Metrics package doesn't provide any reporter itself.
+
+## Metric definitions
+
+[`counter/2`](./Telemetry.Metrics.html#counter/2), [`sum/2`](./Telemetry.Metrics.html#sum/2),
+[`last_value/2`](./Telemetry.Metrics.html#last_value/2) and
+[`distribution/2`](./Telemetry.Metrics.html#distribution/2) functions all return metric defintions.
+
+The most basic metric definition looks like this
+
+```elixir
+sum("http.request.payload_size")
+```
+
+The first argument to the metric definition function is a metric name - this is what the reporter
+will use to identify this metric when publishing it. The metric name also determines what event and
+measurement should be used to produce metric values:
+
+```
+ [:http , :request]    :payload_size
+ <-- event name --> <-- measurement -->
+```
+
+that is, by default, all but last segments of the metric name determine the event name, and the last
+segment determines the measurement.
+
+If you wish to use a different event name or measurement, they can be overriden using `:event_name`
+and `:measurement` options respectively (you can read more about them in the "Shared options"
+section in the docs for [`Telemetry.Metrics`](./Telemetry.Metrics.html#shared-options) module)
+
+## Metric types
+
+Telemetry.Metrics defines four basic metric types:
+  * a counter simply counts the number of emitted events, regardless of measurements included in the
+    events. Since the measurement does not matter in case of a counter, we recommend using `count`
+    as a measurement, e.g. `"http.request.count"`
+  * a `last_value` metric holds the value of a selected measurement found in the most recent event
+  * a sum adds up the values of a selected measurement in all the events
+  * a distribution keeps track of the histogram of the selected measurement, i.e. how many
+    measurements fall into defined buckets. Histogram allows to compute useful statistics about
+    the data, like percentiles, minimum, or maximum.
+
+    For example, given boundaries `[0, 100, 200]`, the distribution metric produces four values:
+      * number of measurements less than or equal to 0
+      * number of measurements greater than 0 and less than or equal to 100
+      * number of measurements greater than 100 and less than or equal to 200
+      * number of measurements greater than 200
+
+Note that not all metric types are supported by all monitoring solutions. However, often they
+support some variation of a particular type. For example, StatsD doesn't have a distribution
+metric as defined here built-in, but it provides a "timer" metric which allows to keep track of
+the percentiles, maximum, etc. That is fine as long as the reporter properly documents the
+differences between the expected and actual behaviour.
+
+It's also possible that a reporter library provides its own, specialized function for building
+metric definitions, for metric types specific to the system it publishes metrics to.
+
+## Breaking down metric values by tags
+
+Sometimes it's not enough to have a global overview of all HTTP requests received or all DB queries
+made. It's often more helpful to break down this data, for example, we might want to have separate
+metric values for each unique database table and operation name (`select`, `insert` etc.) to see
+how these particular queries behave.
+
+This is where tagging comes into play. All metric definitions accept a `:tags` option:
+
+```elixir
+count("db.query.count", tags: [:table, :operation])
+```
+
+The above definition means that we want to keep track of the number of queries, but we want
+a separate counter for each unique pair of table and operation. Tag values are fetched from event
+metadata - this means that in this example, `[:db, :query]` events need to include `:table` and
+`:operation` keys in their payload:
+
+```elixir
+:telemetry.execute([:db, :query], %{duration: 198}, %{table: "users", operation: "insert"})
+:telemetry.execute([:db, :query], %{duration: 112}, %{table: "users", operation: "select"})
+:telemetry.execute([:db, :query], %{duration: 201}, %{table: "sessions", operation: "insert"})
+:telemetry.execute([:db, :query], %{duration: 212}, %{table: "sessions", operation: "insert"})
+```
+
+The result of aggregating the events above looks like this:
+
+| table    | operation | count |
+|----------|-----------|-------|
+| users    | insert    | 1     |
+| users    | select    | 1     |
+| sessions | insert    | 2     |
+
+The approach where we create a separate metric for some unique set of properties is called
+a multi-dimensional data model.
+
+### Transforming event metadata for tagging
+
+Finally, sometimes there is a need to modify event metadata before it's used for tagging. Each
+metric definition accepts a function in `:tag_values` option which transforms the metadata into
+desired shape. Note that this function is called for each event, so it's important to keep it fast
+if the rate of events is high.
+
+## VM metrics
+
+Telemetry.Metrics doesn't have a special treatment for the VM metrics - they need to be based on
+the events like all other metrics.
+
+`Telemetry.Poller` package exposes a bunch of VM-related metrics via `:telemetry` events.
+For example, when you add it to your dependencies, you can create a metric keeping track of total
+allocated VM memory:
+
+    last_value("vm.memory.total")
+
+The last value metric is usually the best fit for VM metrics exposed by the Poller, as the events are
+emitted periodically and we're only interested in the most recent measurement.
+
+You can read more about available events and measurements in the `Telemetry.Poller` documentation.

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -1,0 +1,18 @@
+# Rationale
+
+The design proposed by Telemetry.Metrics might look controversial - unlike most of the libraries
+available on the BEAM, it doesn't aggregate metrics itself, it merely defines what users should
+expect when using the reporters.
+
+If Telemetry.Metrics would aggregate metrics, the way those aggregations work would be imposed
+on the system where the metrics are published to. For example, counters in StatsD are reset on
+every flush and can be decremented, whereas counters in Prometheus are monotonically increasing.
+Telemetry.Metrics doesn't focus on those details - instead, it describes what the end user,
+operator, expects to see when using the metric of particular type. This implies that in most
+cases aggregated metrics won't be visible inside the BEAM, but in exchange aggregations can be
+implemented in a way that makes most sense for particular system.
+
+Finally, one could also implement an in-VM "reporter" which would aggregate the metrics and expose
+them inside the BEAM. When there is a need to swap the reporters, and if both reporters are
+following the metric types specification, then the end result of aggregation is the same,
+regardless of the backend system in use.

--- a/docs/writing_reporters.md
+++ b/docs/writing_reporters.md
@@ -1,0 +1,141 @@
+# Writing reporters
+
+Reporters are a crucial part of Telemetry.Metrics "ecosystem" - without them, metric definitions
+are merely.. definitions. This guide aims to help in writing the reporter in a proper way.
+
+> Before writing the reporter for your favourite monitoring system, make sure that one isn't
+> already available on Hex.pm - it might make sense to contribute and improve the existing solution
+> than starting from scratch.
+
+Let's get started!
+
+## Responsibilites
+
+The reporter has four main responsibilities:
+  * it needs to accept a list of metric definitions as input when being started
+  * it needs to attach handlers to events contained in these definitions
+  * when the events are emitted, it needs to extract the measurement and selected tags, and handle
+    them in a way that makes sense for whathever it chooses to publish to
+  * it needs to detach event handlers when it stops or crashes
+
+### Accepting metric definitions as input
+
+This one is quite easy - you need to give your users a way to actually tell you what metrics they
+want to track. It's essential to give users an option to provide metric definitions at runtime
+(e.g. when their application starts). For example, let's say you're building a `PigeonReporter`.
+If the reporter was process-based, you could provide a `start_link/1` function that accepts a list
+of metric definitions:
+
+```elixir
+  metrics = [
+    counter("..."),
+    last_value("..."),
+    distribution("...")
+  ]
+
+  PigeonReporter.start_link(metrics)
+```
+
+If the reporter doesn't support metrics of particular type, it log a warning or return an error.
+
+### Attaching event handlers
+
+Event handlers are attached using `:telemetry.attach/4` function. To reduce overhead of installing
+many event handlers, you can install a single handler for multiple metrics based on the same event.
+
+Note that handler IDs need to be unique - you can generate completely random blobs of data, or use
+something that you know needs to be unique anyway, e.g. some combination of reporter name,
+event name, and something which is different for multiple instances of the same reporter (PID is a
+good choice if the reporter is process-based):
+
+```elixir
+id = {PigeonReporter, metric.event_name, self()}
+```
+
+Assuming that `metrics` is a list of metric definitions based on `event`, we can attach a handler
+like this:
+
+```elixir
+:telemetry.attach(id, event, &PigeonReporter.handle_event/4, %{metrics: metrics})
+```
+
+### Reacting to events
+
+There are two parts to event handling - the first one is extracting event measurements and tags,
+which is the same for all reporters, and the second one is performing logic specific to particular
+reporter.
+
+Let's implement the basic event handler attached in the previous section:
+
+```elixir
+def handle_event(_event_name, measurements, metadata, %{metrics: metrics}) do
+  for metric <- metrics do
+    measurement = extract_measurement(metric, measurements)
+    tags = extract_tags(metric, metadata)
+    # everything else is specific to particular reporter
+  end
+end
+```
+
+As described before, first we extract the measurement and tags, and later perform reporter-specific
+logic. The implementation of `extract_measurement/2` might look as follows:
+
+```elixir
+def extract_measurement(metric, measurements) do
+  case metric.measurement do
+    fun when is_function(fun, 1) ->
+      fun.(measurements)
+    key ->
+      measurements[key]
+  end
+end
+```
+
+Since `:measurement` in the metric definition can be both arbitrary term (to be used as key to fetch
+the measurement) or a function, we need to handle both cases.
+
+> Note: Telemetry.Metrics can't guarantee that the extracted measurement's value is a number. Each
+> reporter can handle this scenario properly, either by logging a warning, detaching the handler etc.
+
+We also need to implement the `extract_tags/2` function:
+
+```elixir
+def extract_tags(metric, metadata) do
+  tag_values = metric.tag_values.(metadata)
+  for tag <- tags, into: %{} do
+    case Map.fetch(tag_values, tag) do
+      {:ok, value} ->
+        Map.put(tags, tag, value)
+      :error ->
+        Logger.warn("Tag #{inspect(tag)} not found in event metadata: #{inspect(metadata)}")
+        Map.put(tags, tag, nil)
+    end
+  end
+end
+```
+
+First we need to apply last-minute transformation to the metadata using the `:tag_values` function.
+After that, we loop through the list of desired tags and fetch them from transformed metadata - if
+the particular key is not present in the metadata, we log a warning and assign `nil` as the tag value.
+
+It is very important that the code executed on every event does not fail, as that would cause
+the handler to be permanently removed and prevent the metrics from being updated.
+
+### Detaching the handlers on termination
+
+To leave the system in a clean state, the reporter should detach the event handlers it installed
+when it's being stopped or terminated unexpectedely. This can be done by trapping exists and
+implementing the terminate callback, or having a dedicated process responsible only for the cleanup
+(e.g. by using monitors).
+
+## Documentation
+
+It's extremely important that reporters document how `Telemetry.Metrics` metric types, names,
+and tags are translated to metric types and identifiers in the system they publish metrics to.
+They should also document if some metric types are not supported at all.
+
+## Examples
+
+To our knowledge, there are not many reporters in the wild yet.
+[TelemetryMetricsStatsd](https://github.com/arkgil/telemetry_metrics_statsd) is a reporter which
+might serve as an example when implementing your own.

--- a/mix.exs
+++ b/mix.exs
@@ -43,11 +43,15 @@ defmodule Telemetry.Metrics.MixProject do
 
   defp docs do
     [
-      main: "readme",
+      main: "overview",
       canonical: "http://hexdocs.pm/telemetry_metrics",
       source_url: "https://github.com/beam-telemetry/telemetry_metrics",
       source_ref: "v#{@version}",
-      extras: ["README.md"]
+      extras: [
+        "docs/overview.md",
+        "docs/rationale.md",
+        "docs/writing_reporters.md"
+      ]
     ]
   end
 


### PR DESCRIPTION
This changes a few things in the documentation:
- documentation in the Telemetry.Metrics module has been shortened to only provide   a quick information to get started + documentation of all the functions and possible options
- three documentation pages have been added
  - overview, which provides a longer, high-level description of the library and its "ecosystem"
  - rationale
  - a guide for writing reporters

I hope this will make it clearer for newcomers what all of this is actually supposed to do 😄 

/cc @bryannaegele