### PR TITLE
Unit conversions

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -143,6 +143,29 @@ metric definition accepts a function in `:tag_values` option which transforms th
 desired shape. Note that this function is called for each event, so it's important to keep it fast
 if the rate of events is high.
 
+## Converting units
+
+It might happen that the unit of measurement we're tracking is not the desirable unit for the
+metric values, e.g. events are emitted by a 3rd-party library we do not control, or a reporter
+we're using requires specific unit of measurement.
+
+For these scenarios, each metric definition accepts a `:unit` option in a form of a tuple:
+
+```elixir
+distribution("http.request.duration", unit: {from_unit, to_unit})
+```
+
+This means that the measurement will be converted from `from_unit` to `to_unit` before being used
+for updating the metric. Currently, only time conversions are supported, which means that both
+`from_unit` and `to_unit` need to be one of `:second`, `:millisecond`, `:microsecond`,
+`:nanosecond`, or `:native`.
+
+For example, to convert HTTP request duration from `:native` time unit to milliseconds you'd write:
+
+```elixir
+distribution("http.request.duration", unit: {:native, :millisecond})
+```
+
 ## VM metrics
 
 Telemetry.Metrics doesn't have a special treatment for the VM metrics - they need to be based on


### PR DESCRIPTION
This PR allows to specify the conversion of unit of measurement. Currently only time units are supported. If a tuple in a form of `{from, to}` is passed to `:unit` option, the measurement function is wrapped and the measurement is converted to the desired unit. 

The unit conversion relies on the fact that the measurement is a number, but since it's not checked anywhere, we simply crash with a BadArithmetic when performing the conversion.

I'm not sure how to handle converting from smaller to bigger units when it comes to rounding. Currently, e.g. when converting from nanoseconds to milliseconds, the result is a float - however, I think that it would be most convenient if it is an integer. The question is, should we always round down (e.g. by using `div/2` instead of `//2`), or using `round/2`which uses half-up rounding strategy.

Closes #27 

/cc @bryannaegele @binaryseed 