### PR TITLE
Add a summary metric type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ There are four metric types provided by Telemetry.Metrics:
 - counter, which counts the total number of emitted events
 - sum which keeps track of the sum of selected measurement
 - last value, holding the value of the selected measurement from the most recent event
+- statistics, aggregating measurements into summary statistics like minimum and maximum, mean,
+  percentiles etc.
 - distribution, which builds a histogram of selected measurement
 
 Note that the metric definitions themselves are not enough, as they only provide the specification

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -49,7 +49,7 @@ Note that Telemetry.Metrics package doesn't provide any reporter itself.
 
 [`counter/2`](./Telemetry.Metrics.html#counter/2), [`sum/2`](./Telemetry.Metrics.html#sum/2),
 [`last_value/2`](./Telemetry.Metrics.html#last_value/2),
-[`statistics/2`](./Telemetry.Metrics.html#statistics/2) and
+[`summary/2`](./Telemetry.Metrics.html#summary/2) and
 [`distribution/2`](./Telemetry.Metrics.html#distribution/2) functions all return metric defintions.
 
 The most basic metric definition looks like this
@@ -83,9 +83,8 @@ Telemetry.Metrics defines four basic metric types:
   as a measurement, e.g. `"http.request.count"`
 - a `last_value` metric holds the value of a selected measurement found in the most recent event
 - a sum adds up the values of a selected measurement in all the events
-- a statistics metric aggregates measurement values into a set of summary statistics, e.g.
-  minimum and maximum, mean, or percentiles. The exact set of available statistics depends on the
-  reporter in use
+- a summary aggregates measurement values into a set of statistics, e.g. minimum and maximum, mean,
+  or percentiles. The exact set of available statistics depends on the reporter in use
 - a distribution keeps track of the histogram of the selected measurement, i.e. how many
   measurements fall into defined buckets. Histogram allows to compute useful statistics about
   the data, like percentiles, minimum, or maximum.
@@ -156,7 +155,7 @@ we're using requires specific unit of measurement.
 For these scenarios, each metric definition accepts a `:unit` option in a form of a tuple:
 
 ```elixir
-statistics("http.request.duration", unit: {from_unit, to_unit})
+summary("http.request.duration", unit: {from_unit, to_unit})
 ```
 
 This means that the measurement will be converted from `from_unit` to `to_unit` before being used
@@ -167,7 +166,7 @@ for updating the metric. Currently, only time conversions are supported, which m
 For example, to convert HTTP request duration from `:native` time unit to milliseconds you'd write:
 
 ```elixir
-statistics("http.request.duration", unit: {:native, :millisecond})
+summary("http.request.duration", unit: {:native, :millisecond})
 ```
 
 ## VM metrics

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -48,7 +48,8 @@ Note that Telemetry.Metrics package doesn't provide any reporter itself.
 ## Metric definitions
 
 [`counter/2`](./Telemetry.Metrics.html#counter/2), [`sum/2`](./Telemetry.Metrics.html#sum/2),
-[`last_value/2`](./Telemetry.Metrics.html#last_value/2) and
+[`last_value/2`](./Telemetry.Metrics.html#last_value/2),
+[`statistics/2`](./Telemetry.Metrics.html#statistics/2) and
 [`distribution/2`](./Telemetry.Metrics.html#distribution/2) functions all return metric defintions.
 
 The most basic metric definition looks like this
@@ -76,29 +77,32 @@ section in the docs for [`Telemetry.Metrics`](./Telemetry.Metrics.html#shared-op
 ## Metric types
 
 Telemetry.Metrics defines four basic metric types:
-  * a counter simply counts the number of emitted events, regardless of measurements included in the
-    events. Since the measurement does not matter in case of a counter, we recommend using `count`
-    as a measurement, e.g. `"http.request.count"`
-  * a `last_value` metric holds the value of a selected measurement found in the most recent event
-  * a sum adds up the values of a selected measurement in all the events
-  * a distribution keeps track of the histogram of the selected measurement, i.e. how many
-    measurements fall into defined buckets. Histogram allows to compute useful statistics about
-    the data, like percentiles, minimum, or maximum.
 
-    For example, given boundaries `[0, 100, 200]`, the distribution metric produces four values:
-      * number of measurements less than or equal to 0
-      * number of measurements greater than 0 and less than or equal to 100
-      * number of measurements greater than 100 and less than or equal to 200
-      * number of measurements greater than 200
+- a counter simply counts the number of emitted events, regardless of measurements included in the
+  events. Since the measurement does not matter in case of a counter, we recommend using `count`
+  as a measurement, e.g. `"http.request.count"`
+- a `last_value` metric holds the value of a selected measurement found in the most recent event
+- a sum adds up the values of a selected measurement in all the events
+- a statistics metric aggregates measurement values into a set of summary statistics, e.g.
+  minimum and maximum, mean, or percentiles. The exact set of available statistics depends on the
+  reporter in use
+- a distribution keeps track of the histogram of the selected measurement, i.e. how many
+  measurements fall into defined buckets. Histogram allows to compute useful statistics about
+  the data, like percentiles, minimum, or maximum.
 
-Note that not all metric types are supported by all monitoring solutions. However, often they
-support some variation of a particular type. For example, StatsD doesn't have a distribution
-metric as defined here built-in, but it provides a "timer" metric which allows to keep track of
-the percentiles, maximum, etc. That is fine as long as the reporter properly documents the
-differences between the expected and actual behaviour.
+  For example, given boundaries `[0, 100, 200]`, the distribution metric produces four values:
+
+  - number of measurements less than or equal to 0
+  - number of measurements greater than 0 and less than or equal to 100
+  - number of measurements greater than 100 and less than or equal to 200
+  - number of measurements greater than 200
+
+If the monitoring solution doesn't provide metric types exactly as defined above but supports
+metrics resembling them, the reporter should properly document the differences between the expected
+and actual behaviour.
 
 It's also possible that a reporter library provides its own, specialized function for building
-metric definitions, for metric types specific to the system it publishes metrics to.
+metric definitions for metric types specific to the system it publishes metrics to.
 
 ## Breaking down metric values by tags
 
@@ -128,7 +132,7 @@ metadata - this means that in this example, `[:db, :query]` events need to inclu
 The result of aggregating the events above looks like this:
 
 | table    | operation | count |
-|----------|-----------|-------|
+| -------- | --------- | ----- |
 | users    | insert    | 1     |
 | users    | select    | 1     |
 | sessions | insert    | 2     |
@@ -152,7 +156,7 @@ we're using requires specific unit of measurement.
 For these scenarios, each metric definition accepts a `:unit` option in a form of a tuple:
 
 ```elixir
-distribution("http.request.duration", unit: {from_unit, to_unit})
+statistics("http.request.duration", unit: {from_unit, to_unit})
 ```
 
 This means that the measurement will be converted from `from_unit` to `to_unit` before being used
@@ -163,7 +167,7 @@ for updating the metric. Currently, only time conversions are supported, which m
 For example, to convert HTTP request duration from `:native` time unit to milliseconds you'd write:
 
 ```elixir
-distribution("http.request.duration", unit: {:native, :millisecond})
+statistics("http.request.duration", unit: {:native, :millisecond})
 ```
 
 ## VM metrics

--- a/docs/writing_reporters.md
+++ b/docs/writing_reporters.md
@@ -12,11 +12,12 @@ Let's get started!
 ## Responsibilites
 
 The reporter has four main responsibilities:
-  * it needs to accept a list of metric definitions as input when being started
-  * it needs to attach handlers to events contained in these definitions
-  * when the events are emitted, it needs to extract the measurement and selected tags, and handle
-    them in a way that makes sense for whathever it chooses to publish to
-  * it needs to detach event handlers when it stops or crashes
+
+- it needs to accept a list of metric definitions as input when being started
+- it needs to attach handlers to events contained in these definitions
+- when the events are emitted, it needs to extract the measurement and selected tags, and handle
+  them in a way that makes sense for whathever it chooses to publish to
+- it needs to detach event handlers when it stops or crashes
 
 ### Accepting metric definitions as input
 
@@ -30,13 +31,14 @@ of metric definitions:
   metrics = [
     counter("..."),
     last_value("..."),
-    distribution("...")
+    statistics("...")
   ]
 
   PigeonReporter.start_link(metrics)
 ```
 
-If the reporter doesn't support metrics of particular type, it log a warning or return an error.
+If the reporter doesn't support metrics of particular type, it should log a warning or return an
+error.
 
 ### Attaching event handlers
 
@@ -131,8 +133,9 @@ implementing the terminate callback, or having a dedicated process responsible o
 ## Documentation
 
 It's extremely important that reporters document how `Telemetry.Metrics` metric types, names,
-and tags are translated to metric types and identifiers in the system they publish metrics to.
-They should also document if some metric types are not supported at all.
+and tags are translated to metric types and identifiers in the system they publish metrics to
+(this is particularly important for statistics metric which is broadly defined). They should also
+document if some metric types are not supported at all.
 
 ## Examples
 

--- a/docs/writing_reporters.md
+++ b/docs/writing_reporters.md
@@ -31,7 +31,7 @@ of metric definitions:
   metrics = [
     counter("..."),
     last_value("..."),
-    statistics("...")
+    summary("...")
   ]
 
   PigeonReporter.start_link(metrics)
@@ -134,7 +134,7 @@ implementing the terminate callback, or having a dedicated process responsible o
 
 It's extremely important that reporters document how `Telemetry.Metrics` metric types, names,
 and tags are translated to metric types and identifiers in the system they publish metrics to
-(this is particularly important for statistics metric which is broadly defined). They should also
+(this is particularly important for a summary metric which is broadly defined). They should also
 document if some metric types are not supported at all.
 
 ## Examples

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -26,8 +26,8 @@ defmodule Telemetry.Metrics do
     * `counter/2` which counts the total number of emitted events
     * `sum/2` which keeps track of the sum of selected measurement
     * `last_value/2` holding the value of the selected measurement from the most recent event
-    * `statistics/2` calculating summary statistics of the selected measurement, like maximum,
-      mean, percentiles etc.
+    * `summary/2` calculating statistics of the selected measurement, like maximum, mean,
+      percentiles etc.
     * `distribution/2` which builds a histogram of selected measurement
 
   Note that these metric definitions by itself are not enough, as they only provide the specification
@@ -89,7 +89,7 @@ defmodule Telemetry.Metrics do
 
   require Logger
 
-  alias Telemetry.Metrics.{Counter, Sum, LastValue, Statistics, Distribution}
+  alias Telemetry.Metrics.{Counter, Sum, LastValue, Summary, Distribution}
 
   @typedoc """
   The name of the metric, either as string or a list of atoms.
@@ -112,7 +112,7 @@ defmodule Telemetry.Metrics do
   @type counter_options :: [metric_option()]
   @type sum_options :: [metric_option()]
   @type last_value_options :: [metric_option()]
-  @type statistics_options :: [metric_option()]
+  @type summary_options :: [metric_option()]
   @type distribution_options :: [metric_option() | {:buckets, Distribution.buckets()}]
   @type metric_option ::
           {:event_name, :telemetry.event_name()}
@@ -206,25 +206,25 @@ defmodule Telemetry.Metrics do
   end
 
   @doc """
-  Returns a definition of statistics metric.
+  Returns a definition of summary metric.
 
-  This metric aggregates measurement's values into summary statistics, e.g. minimum and maximum,
-  mean, or percentiles. It is up to the reporter to decide which statistics exactly are exposed.
+  This metric aggregates measurement's values into statistics, e.g. minimum and maximum, mean, or
+  percentiles. It is up to the reporter to decide which statistics exactly are exposed.
 
   See the "Metric definitions" section in the top-level documentation of this module for more
   information.
 
   ## Example
 
-      statistics(
+      summary(
         "db.query.duration",
         tags: [:table],
         unit: {:native, :millisecond}
       )
   """
-  @spec statistics(metric_name(), statistics_options()) :: Statistics.t()
-  def statistics(metric_name, options \\ []) do
-    struct(Statistics, common_fields(metric_name, options))
+  @spec summary(metric_name(), summary_options()) :: Summary.t()
+  def summary(metric_name, options \\ []) do
+    struct(Summary, common_fields(metric_name, options))
   end
 
   @doc """

--- a/lib/telemetry_metrics/statistics.ex
+++ b/lib/telemetry_metrics/statistics.ex
@@ -1,6 +1,6 @@
-defmodule Telemetry.Metrics.Statistics do
+defmodule Telemetry.Metrics.Summary do
   @moduledoc """
-  Defines a specification of statistics metric.
+  Defines a specification of summary metric.
   """
 
   alias Telemetry.Metrics

--- a/lib/telemetry_metrics/statistics.ex
+++ b/lib/telemetry_metrics/statistics.ex
@@ -1,0 +1,19 @@
+defmodule Telemetry.Metrics.Statistics do
+  @moduledoc """
+  Defines a specification of statistics metric.
+  """
+
+  alias Telemetry.Metrics
+
+  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
+
+  @type t :: %__MODULE__{
+          name: Metrics.normalized_metric_name(),
+          event_name: :telemetry.event_name(),
+          measurement: Metrics.measurement(),
+          tags: Metrics.tags(),
+          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
+          description: Metrics.description(),
+          unit: Metrics.unit()
+        }
+end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -8,6 +8,7 @@ defmodule Telemetry.MetricsTest do
         counter: [],
         sum: [],
         last_value: [],
+        statistics: [],
         distribution: [buckets: [0, 100, 200]]
       ] do
     describe "#{metric_type}/2" do

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -8,7 +8,7 @@ defmodule Telemetry.MetricsTest do
         counter: [],
         sum: [],
         last_value: [],
-        statistics: [],
+        summary: [],
         distribution: [buckets: [0, 100, 200]]
       ] do
     describe "#{metric_type}/2" do


### PR DESCRIPTION
This PR adds a statistics metric type. Its purpose is to aggregate measurement values into a set of statistics, e.g. min/max, mean, percentiles etc. It is up to reporters to decide (and document) what statistics are actually expose, because it depends on the monitoring system in use.
Statistics are useful in situations where distributions are not available or we don't  know yet what buckets we should choose for the distribution. It also makes sense to use them when there is only one "instance" of the metric (e.g. our application runs only on one node).

I'm still wondering if "statistics" is a good name here. Maybe we should follow Prometheus' steps and use "summary" for this metric type? i'm also considering adding a piece of documentation comparing distribution and statistics, but I'm not sure about it.

/cc @josevalim @bryannaegele @binaryseed