### PR TITLE
Support bytes, kilobytes and megabytes conversion

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -71,7 +71,7 @@ defmodule Telemetry.Metrics do
     * `:unit` - an atom describing the unit of selected measurement, typically in
       singular, such as `:millisecond`, `:byte`, `:kilobyte`, etc. It may also be
       a tuple indicating that a measurement should be converted from one unit to
-      another before a metric is updated. Currently, only time and storage unit
+      another before a metric is updated. Currently, only time and byte unit
       conversions are supported. We discuss those in detail in the "Converting Units"
       section.
 
@@ -125,7 +125,7 @@ defmodule Telemetry.Metrics do
       summary("http.request.stop.duration", unit: {from_unit, to_unit})
 
   This means that the measurement will be converted from `from_unit` to `to_unit` before
-  being used for updating the metric. Currently, only time and storage conversions are
+  being used for updating the metric. Currently, only time and byte conversions are
   supported.
 
   ### Time Conversions
@@ -139,10 +139,10 @@ defmodule Telemetry.Metrics do
 
       summary("http.request.stop.duration", unit: {:native, :millisecond})
 
-  ### Storage Conversions
+  ### Byte Conversions
 
   Some metrics, like VM memory's usage are reported in bytes. You might want to convert this
-  to megabytes, for example. The supported storage units are: `:byte`, `:kilobyte` and `:megabyte`.
+  to megabytes, for example. The supported byte units are: `:byte`, `:kilobyte` and `:megabyte`.
 
   In order to convert a metric value from bytes to megabytes, you can write the following:
 
@@ -270,8 +270,8 @@ defmodule Telemetry.Metrics do
   @type unit :: atom()
   @type time_unit_conversion() :: {time_unit(), time_unit()}
   @type time_unit() :: :second | :millisecond | :microsecond | :nanosecond | :native
-  @type storage_unit() :: :megabyte | :kilobyte | :byte
-  @type storage_unit_conversion() :: {storage_unit(), storage_unit()}
+  @type byte_unit() :: :megabyte | :kilobyte | :byte
+  @type byte_unit_conversion() :: {byte_unit(), byte_unit()}
   @type counter_options :: [metric_option()]
   @type sum_options :: [metric_option()]
   @type last_value_options :: [metric_option()]
@@ -283,7 +283,7 @@ defmodule Telemetry.Metrics do
           | {:tags, tags()}
           | {:tag_values, tag_values()}
           | {:description, description()}
-          | {:unit, unit() | time_unit_conversion() | storage_unit_conversion()}
+          | {:unit, unit() | time_unit_conversion() | byte_unit_conversion()}
 
   @typedoc """
   Common fields for metric specifications
@@ -567,13 +567,13 @@ defmodule Telemetry.Metrics do
       time_unit?(from_unit) and time_unit?(to_unit) ->
         {to_unit, time_unit_conversion_ratio(from_unit, to_unit)}
 
-      storage_unit?(from_unit) and storage_unit?(to_unit) ->
-        {to_unit, storage_unit_conversion_ratio(from_unit, to_unit)}
+      byte_unit?(from_unit) and byte_unit?(to_unit) ->
+        {to_unit, byte_unit_conversion_ratio(from_unit, to_unit)}
 
       true ->
         raise ArgumentError,
               "expected both elements of the unit conversion tuple" <>
-                "to represent time or storage units, got #{inspect(t)}"
+                "to represent time or byte units, got #{inspect(t)}"
     end
   end
 
@@ -600,17 +600,17 @@ defmodule Telemetry.Metrics do
     end
   end
 
-  @spec storage_unit_conversion_ratio(storage_unit(), storage_unit()) :: number()
-  defp storage_unit_conversion_ratio(from_unit, to_unit) do
-    multiplier = storage_unit_factor(to_unit)
-    divisor = storage_unit_factor(from_unit)
+  @spec byte_unit_conversion_ratio(byte_unit(), byte_unit()) :: number()
+  defp byte_unit_conversion_ratio(from_unit, to_unit) do
+    multiplier = byte_unit_factor(to_unit)
+    divisor = byte_unit_factor(from_unit)
     1 * multiplier / divisor
   end
 
-  @spec storage_unit_factor(storage_unit()) :: number()
-  defp storage_unit_factor(:megabyte), do: 1
-  defp storage_unit_factor(:kilobyte), do: 1_000
-  defp storage_unit_factor(:byte), do: 1_000_000
+  @spec byte_unit_factor(byte_unit()) :: number()
+  defp byte_unit_factor(:megabyte), do: 1
+  defp byte_unit_factor(:kilobyte), do: 1_000
+  defp byte_unit_factor(:byte), do: 1_000_000
 
   @spec time_unit?(term()) :: boolean()
   defp time_unit?(:native), do: true
@@ -620,11 +620,11 @@ defmodule Telemetry.Metrics do
   defp time_unit?(:nanosecond), do: true
   defp time_unit?(_), do: false
 
-  @spec storage_unit?(term()) :: boolean()
-  defp storage_unit?(:byte), do: true
-  defp storage_unit?(:kilobyte), do: true
-  defp storage_unit?(:megabyte), do: true
-  defp storage_unit?(_), do: false
+  @spec byte_unit?(term()) :: boolean()
+  defp byte_unit?(:byte), do: true
+  defp byte_unit?(:kilobyte), do: true
+  defp byte_unit?(:megabyte), do: true
+  defp byte_unit?(_), do: false
 
   @spec validate_distribution_buckets!(term()) :: :ok | no_return()
   defp validate_distribution_buckets!([_ | _] = buckets) do

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -71,8 +71,9 @@ defmodule Telemetry.Metrics do
     * `:unit` - an atom describing the unit of selected measurement, typically in
       singular, such as `:millisecond`, `:byte`, `:kilobyte`, etc. It may also be
       a tuple indicating that a measurement should be converted from one unit to
-      another before a metric is updated. Currently, only time unit conversions
-      are supported. We discuss those in detail in the "Converting Units" section.
+      another before a metric is updated. Currently, only time and storage unit
+      conversions are supported. We discuss those in detail in the "Converting Units"
+      section.
 
   ## Breaking down metric values by tags
 
@@ -124,16 +125,28 @@ defmodule Telemetry.Metrics do
       summary("http.request.stop.duration", unit: {from_unit, to_unit})
 
   This means that the measurement will be converted from `from_unit` to `to_unit` before
-  being used for updating the metric. Currently, only time conversions are supported,
-  which means that both `from_unit` and `to_unit` need to be one of `:second`, `:millisecond`,
-  `:microsecond`, `:nanosecond`, or `:native`. That's because most time measurements
-  in the Erlang VM are done in the `:native` unit, which we need to convert to the desired
-  precision.
+  being used for updating the metric. Currently, only time and storage conversions are
+  supported.
+
+  ### Time Conversions
+
+  Most time measurements in the Erlang VM are done in the `:native` unit, which we need
+  to convert to the desired precision. The supported time units are: `:second`, `:millisecond`,
+  `:microsecond`, `:nanosecond` and `:native`.
 
   For example, to convert HTTP request duration from `:native` time unit to milliseconds
   you'd write:
 
       summary("http.request.stop.duration", unit: {:native, :millisecond})
+
+  ### Storage Conversions
+
+  Some metrics, like VM memory's usage are reported in bytes. You might want to convert this
+  to megabytes, for example. The supported storage units are: `:byte`, `:kilobyte` and `:megabyte`.
+
+  In order to convert a metric value from bytes to megabytes, you can write the following:
+
+      last_value("vm.memory.total", unit: {:byte, :megabyte})
 
   ## VM metrics
 
@@ -255,8 +268,10 @@ defmodule Telemetry.Metrics do
   @type tag_values :: (:telemetry.event_metadata() -> :telemetry.event_metadata())
   @type description :: nil | String.t()
   @type unit :: atom()
-  @type unit_conversion() :: {time_unit(), time_unit()}
+  @type time_unit_conversion() :: {time_unit(), time_unit()}
   @type time_unit() :: :second | :millisecond | :microsecond | :nanosecond | :native
+  @type storage_unit() :: :megabyte | :kilobyte | :byte
+  @type storage_unit_conversion() :: {storage_unit(), storage_unit()}
   @type counter_options :: [metric_option()]
   @type sum_options :: [metric_option()]
   @type last_value_options :: [metric_option()]
@@ -268,7 +283,7 @@ defmodule Telemetry.Metrics do
           | {:tags, tags()}
           | {:tag_values, tag_values()}
           | {:description, description()}
-          | {:unit, unit() | unit_conversion()}
+          | {:unit, unit() | time_unit_conversion() | storage_unit_conversion()}
 
   @typedoc """
   Common fields for metric specifications
@@ -525,12 +540,13 @@ defmodule Telemetry.Metrics do
     end
   end
 
+  # Don't wrap measurement if no conversion is required.
   @spec maybe_convert_measurement(measurement(), conversion_ratio :: non_neg_integer()) ::
           measurement()
-  defp maybe_convert_measurement(measurement, 1) do
-    # Don't wrap measurement if no conversion is required.
-    measurement
-  end
+  defp maybe_convert_measurement(measurement, 1), do: measurement
+
+  @spec maybe_convert_measurement(measurement(), conversion_ratio :: float()) :: measurement()
+  defp maybe_convert_measurement(measurement, 1.0), do: measurement
 
   defp maybe_convert_measurement(measurement, conversion_ratio)
        when is_function(measurement, 1) do
@@ -547,12 +563,17 @@ defmodule Telemetry.Metrics do
 
   @spec validate_unit!(term()) :: {unit(), conversion_ratio :: number()} | no_return()
   defp validate_unit!({from_unit, to_unit} = t) do
-    if time_unit?(from_unit) and time_unit?(to_unit) do
-      {to_unit, conversion_ratio(from_unit, to_unit)}
-    else
-      raise ArgumentError,
-            "expected both elements of the unit conversion tuple" <>
-              "to represent time units, got #{inspect(t)}"
+    cond do
+      time_unit?(from_unit) and time_unit?(to_unit) ->
+        {to_unit, time_unit_conversion_ratio(from_unit, to_unit)}
+
+      storage_unit?(from_unit) and storage_unit?(to_unit) ->
+        {to_unit, storage_unit_conversion_ratio(from_unit, to_unit)}
+
+      true ->
+        raise ArgumentError,
+              "expected both elements of the unit conversion tuple" <>
+                "to represent time or storage units, got #{inspect(t)}"
     end
   end
 
@@ -566,10 +587,10 @@ defmodule Telemetry.Metrics do
   end
 
   # Maybe warn or raise if the result of conversion is 0?
-  @spec conversion_ratio(time_unit(), time_unit()) :: number()
-  defp conversion_ratio(unit, unit), do: 1
+  @spec time_unit_conversion_ratio(time_unit(), time_unit()) :: number()
+  defp time_unit_conversion_ratio(unit, unit), do: 1
 
-  defp conversion_ratio(from_unit, to_unit) do
+  defp time_unit_conversion_ratio(from_unit, to_unit) do
     case System.convert_time_unit(1, from_unit, to_unit) do
       0 ->
         1 / System.convert_time_unit(1, to_unit, from_unit)
@@ -579,6 +600,18 @@ defmodule Telemetry.Metrics do
     end
   end
 
+  @spec storage_unit_conversion_ratio(storage_unit(), storage_unit()) :: number()
+  defp storage_unit_conversion_ratio(from_unit, to_unit) do
+    multiplier = storage_unit_factor(to_unit)
+    divisor = storage_unit_factor(from_unit)
+    1 * multiplier / divisor
+  end
+
+  @spec storage_unit_factor(storage_unit()) :: number()
+  defp storage_unit_factor(:megabyte), do: 1
+  defp storage_unit_factor(:kilobyte), do: 1_000
+  defp storage_unit_factor(:byte), do: 1_000_000
+
   @spec time_unit?(term()) :: boolean()
   defp time_unit?(:native), do: true
   defp time_unit?(:second), do: true
@@ -586,6 +619,12 @@ defmodule Telemetry.Metrics do
   defp time_unit?(:microsecond), do: true
   defp time_unit?(:nanosecond), do: true
   defp time_unit?(_), do: false
+
+  @spec storage_unit?(term()) :: boolean()
+  defp storage_unit?(:byte), do: true
+  defp storage_unit?(:kilobyte), do: true
+  defp storage_unit?(:megabyte), do: true
+  defp storage_unit?(_), do: false
 
   @spec validate_distribution_buckets!(term()) :: :ok | no_return()
   defp validate_distribution_buckets!([_ | _] = buckets) do

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -540,13 +540,12 @@ defmodule Telemetry.Metrics do
     end
   end
 
-  # Don't wrap measurement if no conversion is required.
   @spec maybe_convert_measurement(measurement(), conversion_ratio :: non_neg_integer()) ::
           measurement()
-  defp maybe_convert_measurement(measurement, 1), do: measurement
-
-  @spec maybe_convert_measurement(measurement(), conversion_ratio :: float()) :: measurement()
-  defp maybe_convert_measurement(measurement, 1.0), do: measurement
+  defp maybe_convert_measurement(measurement, 1) do
+    # Don't wrap measurement if no conversion is required.
+    measurement
+  end
 
   defp maybe_convert_measurement(measurement, conversion_ratio)
        when is_function(measurement, 1) do
@@ -601,6 +600,8 @@ defmodule Telemetry.Metrics do
   end
 
   @spec byte_unit_conversion_ratio(byte_unit(), byte_unit()) :: number()
+  defp byte_unit_conversion_ratio(from_unit, to_unit) when from_unit == to_unit, do: 1
+
   defp byte_unit_conversion_ratio(from_unit, to_unit) do
     multiplier = byte_unit_factor(to_unit)
     divisor = byte_unit_factor(from_unit)

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -600,7 +600,7 @@ defmodule Telemetry.Metrics do
   end
 
   @spec byte_unit_conversion_ratio(byte_unit(), byte_unit()) :: number()
-  defp byte_unit_conversion_ratio(from_unit, to_unit) when from_unit == to_unit, do: 1
+  defp byte_unit_conversion_ratio(unit, unit), do: 1
 
   defp byte_unit_conversion_ratio(from_unit, to_unit) do
     multiplier = byte_unit_factor(to_unit)

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -329,7 +329,16 @@ defmodule Telemetry.MetricsTest do
       end
 
       test "doesn't convert a unit if both units are the same" do
-        for unit <- [:native, :second, :millisecond, :microsecond, :nanosecond] do
+        for unit <- [
+              :native,
+              :second,
+              :millisecond,
+              :microsecond,
+              :nanosecond,
+              :byte,
+              :kilobyte,
+              :megabyte
+            ] do
           metric =
             apply(Metrics, unquote(metric_type), [
               "http.request.latency",
@@ -352,14 +361,97 @@ defmodule Telemetry.MetricsTest do
           metric =
             apply(Metrics, unquote(metric_type), [
               "http.request.latency",
-              [unit: {from, to}] ++
-                unquote(extra_options)
+              [unit: {from, to}] ++ unquote(extra_options)
             ])
 
           measurements = %{latency: measurement}
 
           assert metric.measurement.(measurements) == converted_unit(measurement, from, to)
         end
+      end
+
+      test "converts a measurement under key from byte to kilobyte" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:byte, :kilobyte}] ++ unquote(extra_options)
+          ])
+
+        measurement = 76_000_000
+
+        measurements = %{latency: measurement}
+
+        assert metric.measurement.(measurements) == 76_000
+      end
+
+      test "converts a measurement under key from byte to megabyte" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:byte, :megabyte}] ++ unquote(extra_options)
+          ])
+
+        measurement = 76_000_000
+
+        measurements = %{latency: measurement}
+
+        assert metric.measurement.(measurements) == 76
+      end
+
+      test "converts a measurement under key from kilobyte to byte" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:kilobyte, :byte}] ++ unquote(extra_options)
+          ])
+
+        measurement = 76_000
+
+        measurements = %{latency: measurement}
+
+        assert metric.measurement.(measurements) == 76_000_000
+      end
+
+      test "converts a measurement under key from kilobyte to megabyte" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:kilobyte, :megabyte}] ++ unquote(extra_options)
+          ])
+
+        measurement = 76_000
+
+        measurements = %{latency: measurement}
+
+        assert metric.measurement.(measurements) == 76
+      end
+
+      test "converts a measurement under key from megabyte to byte" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:megabyte, :byte}] ++ unquote(extra_options)
+          ])
+
+        measurement = 76
+
+        measurements = %{latency: measurement}
+
+        assert metric.measurement.(measurements) == 76_000_000
+      end
+
+      test "converts a measurement under key from megabyte to kilobyte" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:megabyte, :kilobyte}] ++ unquote(extra_options)
+          ])
+
+        measurement = 76
+
+        measurements = %{latency: measurement}
+
+        assert metric.measurement.(measurements) == 76_000
       end
 
       test "converts a result of measurement function from one regular time unit to another" do
@@ -375,6 +467,78 @@ defmodule Telemetry.MetricsTest do
 
           assert metric.measurement.(%{}) == converted_unit(measurement, from, to)
         end
+      end
+
+      test "converts a result of measurement function from byte to kilobyte" do
+        measurement = fn _ -> 76_000_000 end
+
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:byte, :kilobyte}, measurement: measurement] ++ unquote(extra_options)
+          ])
+
+        assert metric.measurement.(%{}) == 76_000
+      end
+
+      test "converts a result of measurement function from byte to megabyte" do
+        measurement = fn _ -> 76_000_000 end
+
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:byte, :megabyte}, measurement: measurement] ++ unquote(extra_options)
+          ])
+
+        assert metric.measurement.(%{}) == 76
+      end
+
+      test "converts a result of measurement function from kilobyte to byte" do
+        measurement = fn _ -> 76_000 end
+
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:kilobyte, :byte}, measurement: measurement] ++ unquote(extra_options)
+          ])
+
+        assert metric.measurement.(%{}) == 76_000_000
+      end
+
+      test "converts a result of measurement function from kilobyte to megabyte" do
+        measurement = fn _ -> 76_000 end
+
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:kilobyte, :megabyte}, measurement: measurement] ++ unquote(extra_options)
+          ])
+
+        assert metric.measurement.(%{}) == 76
+      end
+
+      test "converts a result of measurement function from megabyte to byte" do
+        measurement = fn _ -> 76 end
+
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:megabyte, :byte}, measurement: measurement] ++ unquote(extra_options)
+          ])
+
+        assert metric.measurement.(%{}) == 76_000_000
+      end
+
+      test "converts a result of measurement function from megabyte to kilobyte" do
+        measurement = fn _ -> 76 end
+
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.latency",
+            [unit: {:megabyte, :kilobyte}, measurement: measurement] ++ unquote(extra_options)
+          ])
+
+        assert metric.measurement.(%{}) == 76_000
       end
     end
   end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -370,14 +370,14 @@ defmodule Telemetry.MetricsTest do
         end
       end
 
-      test "converts a measurement under key one storage time unit to another" do
+      test "converts a measurement under key from one byte unit to another" do
         units = [
           {{:byte, 76_000_000}, {:kilobyte, 76_000}},
           {{:byte, 76_000_000}, {:megabyte, 76}},
           {{:kilobyte, 76_000}, {:byte, 76_000_000}},
           {{:kilobyte, 76_000}, {:megabyte, 76}},
           {{:megabyte, 76}, {:byte, 76_000_000}},
-          {{:megabyte, 76}, {:kilobyte, 76_000}},
+          {{:megabyte, 76}, {:kilobyte, 76_000}}
         ]
 
         for {{from, original}, {to, converted}} <- units do
@@ -408,14 +408,14 @@ defmodule Telemetry.MetricsTest do
         end
       end
 
-      test "converts a result of measurement function from one regular storage unit to another" do
+      test "converts a result of measurement function from one regular byte unit to another" do
         units = [
           {{:byte, 76_000_000}, {:kilobyte, 76_000}},
           {{:byte, 76_000_000}, {:megabyte, 76}},
           {{:kilobyte, 76_000}, {:byte, 76_000_000}},
           {{:kilobyte, 76_000}, {:megabyte, 76}},
           {{:megabyte, 76}, {:byte, 76_000_000}},
-          {{:megabyte, 76}, {:kilobyte, 76_000}},
+          {{:megabyte, 76}, {:kilobyte, 76_000}}
         ]
 
         for {{from, original}, {to, converted}} <- units do

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -370,88 +370,27 @@ defmodule Telemetry.MetricsTest do
         end
       end
 
-      test "converts a measurement under key from byte to kilobyte" do
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:byte, :kilobyte}] ++ unquote(extra_options)
-          ])
+      test "converts a measurement under key one storage time unit to another" do
+        units = [
+          {{:byte, 76_000_000}, {:kilobyte, 76_000}},
+          {{:byte, 76_000_000}, {:megabyte, 76}},
+          {{:kilobyte, 76_000}, {:byte, 76_000_000}},
+          {{:kilobyte, 76_000}, {:megabyte, 76}},
+          {{:megabyte, 76}, {:byte, 76_000_000}},
+          {{:megabyte, 76}, {:kilobyte, 76_000}},
+        ]
 
-        measurement = 76_000_000
+        for {{from, original}, {to, converted}} <- units do
+          metric =
+            apply(Metrics, unquote(metric_type), [
+              "http.request.latency",
+              [unit: {from, to}] ++ unquote(extra_options)
+            ])
 
-        measurements = %{latency: measurement}
+          measurements = %{latency: original}
 
-        assert metric.measurement.(measurements) == 76_000
-      end
-
-      test "converts a measurement under key from byte to megabyte" do
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:byte, :megabyte}] ++ unquote(extra_options)
-          ])
-
-        measurement = 76_000_000
-
-        measurements = %{latency: measurement}
-
-        assert metric.measurement.(measurements) == 76
-      end
-
-      test "converts a measurement under key from kilobyte to byte" do
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:kilobyte, :byte}] ++ unquote(extra_options)
-          ])
-
-        measurement = 76_000
-
-        measurements = %{latency: measurement}
-
-        assert metric.measurement.(measurements) == 76_000_000
-      end
-
-      test "converts a measurement under key from kilobyte to megabyte" do
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:kilobyte, :megabyte}] ++ unquote(extra_options)
-          ])
-
-        measurement = 76_000
-
-        measurements = %{latency: measurement}
-
-        assert metric.measurement.(measurements) == 76
-      end
-
-      test "converts a measurement under key from megabyte to byte" do
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:megabyte, :byte}] ++ unquote(extra_options)
-          ])
-
-        measurement = 76
-
-        measurements = %{latency: measurement}
-
-        assert metric.measurement.(measurements) == 76_000_000
-      end
-
-      test "converts a measurement under key from megabyte to kilobyte" do
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:megabyte, :kilobyte}] ++ unquote(extra_options)
-          ])
-
-        measurement = 76
-
-        measurements = %{latency: measurement}
-
-        assert metric.measurement.(measurements) == 76_000
+          assert metric.measurement.(measurements) == converted
+        end
       end
 
       test "converts a result of measurement function from one regular time unit to another" do
@@ -469,76 +408,27 @@ defmodule Telemetry.MetricsTest do
         end
       end
 
-      test "converts a result of measurement function from byte to kilobyte" do
-        measurement = fn _ -> 76_000_000 end
+      test "converts a result of measurement function from one regular storage unit to another" do
+        units = [
+          {{:byte, 76_000_000}, {:kilobyte, 76_000}},
+          {{:byte, 76_000_000}, {:megabyte, 76}},
+          {{:kilobyte, 76_000}, {:byte, 76_000_000}},
+          {{:kilobyte, 76_000}, {:megabyte, 76}},
+          {{:megabyte, 76}, {:byte, 76_000_000}},
+          {{:megabyte, 76}, {:kilobyte, 76_000}},
+        ]
 
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:byte, :kilobyte}, measurement: measurement] ++ unquote(extra_options)
-          ])
+        for {{from, original}, {to, converted}} <- units do
+          measurement = fn _ -> original end
 
-        assert metric.measurement.(%{}) == 76_000
-      end
+          metric =
+            apply(Metrics, unquote(metric_type), [
+              "http.request.latency",
+              [unit: {from, to}, measurement: measurement] ++ unquote(extra_options)
+            ])
 
-      test "converts a result of measurement function from byte to megabyte" do
-        measurement = fn _ -> 76_000_000 end
-
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:byte, :megabyte}, measurement: measurement] ++ unquote(extra_options)
-          ])
-
-        assert metric.measurement.(%{}) == 76
-      end
-
-      test "converts a result of measurement function from kilobyte to byte" do
-        measurement = fn _ -> 76_000 end
-
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:kilobyte, :byte}, measurement: measurement] ++ unquote(extra_options)
-          ])
-
-        assert metric.measurement.(%{}) == 76_000_000
-      end
-
-      test "converts a result of measurement function from kilobyte to megabyte" do
-        measurement = fn _ -> 76_000 end
-
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:kilobyte, :megabyte}, measurement: measurement] ++ unquote(extra_options)
-          ])
-
-        assert metric.measurement.(%{}) == 76
-      end
-
-      test "converts a result of measurement function from megabyte to byte" do
-        measurement = fn _ -> 76 end
-
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:megabyte, :byte}, measurement: measurement] ++ unquote(extra_options)
-          ])
-
-        assert metric.measurement.(%{}) == 76_000_000
-      end
-
-      test "converts a result of measurement function from megabyte to kilobyte" do
-        measurement = fn _ -> 76 end
-
-        metric =
-          apply(Metrics, unquote(metric_type), [
-            "http.request.latency",
-            [unit: {:megabyte, :kilobyte}, measurement: measurement] ++ unquote(extra_options)
-          ])
-
-        assert metric.measurement.(%{}) == 76_000
+          assert metric.measurement.(%{}) == converted
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

Some metrics, like the Erlang VM's memory usage, are reported in bytes. It might be interesting for some reporters to have the ability to convert this value a bigger unit.

Here's an example of a memory usage graph using bytes vs one using megabytes:

<p align="center">
<img src="https://user-images.githubusercontent.com/3727827/64048126-38593e00-cb47-11e9-948b-785d661095d4.png" alt="bytes" width="372" height="311">
</p>

<p align="center">
<img src="https://user-images.githubusercontent.com/3727827/64048130-3b542e80-cb47-11e9-8da4-07dd0b79fa47.png" alt="megabytes" width="472" height="394">
</p>

## 1000 vs 1024

The International System of Units (SI) definition was used here, which means that 1 Kilobyte is defined as 1000 bytes instead of 1024.
This definition was chosen to avoid ambiguity since it seems like 1024 notation should now be called kibibytes, mebibytes, gibibytes and so on. This is also the conversion used by Google:

![Screen Shot 2019-08-30 at 15 13 14](https://user-images.githubusercontent.com/3727827/64048517-51162380-cb48-11e9-9aac-796a1131d339.png)

If you think we're better off using the 1024 definition, please let me know.

References:

- https://physics.nist.gov/cuu/Units/binary.html
- https://en.wikipedia.org/wiki/Kilobyte
- https://cseducators.stackexchange.com/questions/4425/should-i-teach-that-1-kb-1024-bytes-or-1000-bytes