### PR TITLE
Fix error message on wrong conversion

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -649,7 +649,7 @@ defmodule Telemetry.Metrics do
 
       true ->
         raise ArgumentError,
-              "expected both elements of the unit conversion tuple" <>
+              "expected both elements of the unit conversion tuple " <>
                 "to represent time or byte units, got #{inspect(t)}"
     end
   end


### PR DESCRIPTION
Before this patch it was:

    ** (ArgumentError) expected both elements of the unit conversion tupleto represent time or byte units, got {:native, :bad}