### PR TITLE
Implement reporter options

### DIFF
--- a/docs/writing_reporters.md
+++ b/docs/writing_reporters.md
@@ -44,6 +44,10 @@ If the reporter doesn't support metrics of particular type, it may either:
 
 We recommend all reporters to include a summary table of which metrics are supported and their equivalents on the adapter terminology.
 
+Reporter-specific options for individual metrics may be passed on the `:reporter_options` key of the metric definitions. These options
+can be used to define options such as sample rates, percentiles, rates, etc. Reporters should validate any options they accept and
+provide useful exception messages.
+
 ### Attaching event handlers
 
 Event handlers are attached using `:telemetry.attach/4` function. To reduce overhead of installing

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -74,6 +74,7 @@ defmodule Telemetry.Metrics do
       another before a metric is updated. Currently, only time and byte unit
       conversions are supported. We discuss those in detail in the "Converting Units"
       section.
+    * `:reporter_options` - a keyword list of reporter-specific options for the metric.
 
   ## Breaking down metric values by tags
 
@@ -355,6 +356,7 @@ defmodule Telemetry.Metrics do
   @type last_value_options :: [metric_option()]
   @type summary_options :: [metric_option()]
   @type distribution_options :: [metric_option() | {:buckets, Distribution.buckets()}]
+  @type reporter_options :: keyword()
   @type metric_option ::
           {:event_name, :telemetry.event_name()}
           | {:measurement, measurement()}
@@ -362,6 +364,7 @@ defmodule Telemetry.Metrics do
           | {:tag_values, tag_values()}
           | {:description, description()}
           | {:unit, unit() | time_unit_conversion() | byte_unit_conversion()}
+          | {:reporter_options, reporter_options()}
 
   @typedoc """
   Common fields for metric specifications
@@ -376,7 +379,8 @@ defmodule Telemetry.Metrics do
           tags: tags(),
           tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: description(),
-          unit: unit()
+          unit: unit(),
+          reporter_options: reporter_options()
         }
 
   # API
@@ -579,7 +583,8 @@ defmodule Telemetry.Metrics do
     [
       tags: [],
       tag_values: & &1,
-      description: nil
+      description: nil,
+      reporter_options: []
     ]
   end
 
@@ -588,6 +593,9 @@ defmodule Telemetry.Metrics do
     if tags = Keyword.get(options, :tags), do: validate_tags!(tags)
     if tag_values = Keyword.get(options, :tag_values), do: validate_tag_values!(tag_values)
     if description = Keyword.get(options, :description), do: validate_description!(description)
+
+    if reporter_options = Keyword.get(options, :reporter_options),
+      do: validate_reporter_options!(reporter_options)
   end
 
   @spec validate_tags!(term()) :: :ok | no_return()
@@ -615,6 +623,16 @@ defmodule Telemetry.Metrics do
       :ok
     else
       raise ArgumentError, "expected description to be a string, got #{inspect(term)}"
+    end
+  end
+
+  @spec validate_reporter_options!(term()) :: :ok | no_return()
+  defp validate_reporter_options!(reporter_options) do
+    if Keyword.keyword?(reporter_options) do
+      :ok
+    else
+      raise ArgumentError,
+            "expected reporter options to be a keyword list, got #{inspect(reporter_options)}"
     end
   end
 

--- a/lib/telemetry_metrics/counter.ex
+++ b/lib/telemetry_metrics/counter.ex
@@ -5,7 +5,16 @@ defmodule Telemetry.Metrics.Counter do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
+  defstruct [
+    :name,
+    :event_name,
+    :measurement,
+    :tags,
+    :tag_values,
+    :description,
+    :unit,
+    :reporter_options
+  ]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
@@ -14,6 +23,7 @@ defmodule Telemetry.Metrics.Counter do
           tags: Metrics.tags(),
           tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: Metrics.description(),
-          unit: Metrics.unit()
+          unit: Metrics.unit(),
+          reporter_options: Metrics.reporter_options()
         }
 end

--- a/lib/telemetry_metrics/distribution.ex
+++ b/lib/telemetry_metrics/distribution.ex
@@ -5,7 +5,17 @@ defmodule Telemetry.Metrics.Distribution do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :buckets, :description, :unit]
+  defstruct [
+    :name,
+    :event_name,
+    :measurement,
+    :tags,
+    :tag_values,
+    :buckets,
+    :description,
+    :unit,
+    :reporter_options
+  ]
 
   @typedoc """
   Distribution metric bucket boundaries.
@@ -30,6 +40,7 @@ defmodule Telemetry.Metrics.Distribution do
           tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           buckets: buckets(),
           description: Metrics.description(),
-          unit: Metrics.unit()
+          unit: Metrics.unit(),
+          reporter_options: Metrics.reporter_options()
         }
 end

--- a/lib/telemetry_metrics/last_value.ex
+++ b/lib/telemetry_metrics/last_value.ex
@@ -5,7 +5,16 @@ defmodule Telemetry.Metrics.LastValue do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
+  defstruct [
+    :name,
+    :event_name,
+    :measurement,
+    :tags,
+    :tag_values,
+    :description,
+    :unit,
+    :reporter_options
+  ]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
@@ -14,6 +23,7 @@ defmodule Telemetry.Metrics.LastValue do
           tags: Metrics.tags(),
           tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: Metrics.description(),
-          unit: Metrics.unit()
+          unit: Metrics.unit(),
+          reporter_options: Metrics.reporter_options()
         }
 end

--- a/lib/telemetry_metrics/sum.ex
+++ b/lib/telemetry_metrics/sum.ex
@@ -5,7 +5,16 @@ defmodule Telemetry.Metrics.Sum do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
+  defstruct [
+    :name,
+    :event_name,
+    :measurement,
+    :tags,
+    :tag_values,
+    :description,
+    :unit,
+    :reporter_options
+  ]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
@@ -14,6 +23,7 @@ defmodule Telemetry.Metrics.Sum do
           tags: Metrics.tags(),
           tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: Metrics.description(),
-          unit: Metrics.unit()
+          unit: Metrics.unit(),
+          reporter_options: Metrics.reporter_options()
         }
 end

--- a/lib/telemetry_metrics/summary.ex
+++ b/lib/telemetry_metrics/summary.ex
@@ -5,7 +5,16 @@ defmodule Telemetry.Metrics.Summary do
 
   alias Telemetry.Metrics
 
-  defstruct [:name, :event_name, :measurement, :tags, :tag_values, :description, :unit]
+  defstruct [
+    :name,
+    :event_name,
+    :measurement,
+    :tags,
+    :tag_values,
+    :description,
+    :unit,
+    :reporter_options
+  ]
 
   @type t :: %__MODULE__{
           name: Metrics.normalized_metric_name(),
@@ -14,6 +23,7 @@ defmodule Telemetry.Metrics.Summary do
           tags: Metrics.tags(),
           tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
           description: Metrics.description(),
-          unit: Metrics.unit()
+          unit: Metrics.unit(),
+          reporter_options: Metrics.reporter_options()
         }
 end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -55,6 +55,13 @@ defmodule Telemetry.MetricsTest do
         end
       end
 
+      test "raises when reporter options is invalid" do
+        assert_raise ArgumentError, fn ->
+          options = [reporter_options: [:avg]] ++ unquote(extra_options)
+          apply(Metrics, unquote(metric_type), ["my.metric", options])
+        end
+      end
+
       test "returns #{metric_type} specification with default fields" do
         name = "http.request.latency"
         options = [] ++ unquote(extra_options)
@@ -67,6 +74,7 @@ defmodule Telemetry.MetricsTest do
         assert nil == metric.description
         assert :unit == metric.unit
         assert :latency = metric.measurement
+        assert [] = metric.reporter_options
         tag_values_fun = metric.tag_values
         assert %{key: 1, another_key: 2} == tag_values_fun.(%{key: 1, another_key: 2})
       end
@@ -79,6 +87,7 @@ defmodule Telemetry.MetricsTest do
         tags = [:controller, "controller_action"]
         description = "a metric"
         unit = :second
+        reporter_options = [sample_rate: 0.1]
 
         options =
           [
@@ -87,7 +96,8 @@ defmodule Telemetry.MetricsTest do
             tags: tags,
             tag_values: tag_values,
             description: description,
-            unit: unit
+            unit: unit,
+            reporter_options: reporter_options
           ] ++ unquote(extra_options)
 
         metric = apply(Metrics, unquote(metric_type), [name, options])
@@ -98,6 +108,7 @@ defmodule Telemetry.MetricsTest do
         assert description == metric.description
         assert unit == metric.unit
         assert :other_value = metric.measurement
+        assert reporter_options == metric.reporter_options
         tag_values_fun = metric.tag_values
 
         assert %{:controller => UserController, "controller_action" => "create"} ==


### PR DESCRIPTION
With the addition of the Summary metric, the need for reporter options is now needed to provide a mechanism for users to define options for which summary statistics to calculate and rates where appropriate. Prometheus, for instance, requires the time-window for the metric to be set by the user for Summaries. This PR is necessary to support the Summary type in Prometheus Core - beam-telemetry/telemetry_metrics_prometheus_core#11.

Closes #33 