### PR TITLE
Change t() type to cover base metric definitions

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -367,21 +367,9 @@ defmodule Telemetry.Metrics do
           | {:reporter_options, reporter_options()}
 
   @typedoc """
-  Common fields for metric specifications
-
-  Reporters should assume that these fields are present in all metric specifications.
+  One of the base metric definitions.
   """
-  @type t :: %{
-          __struct__: module(),
-          name: normalized_metric_name(),
-          measurement: measurement(),
-          event_name: :telemetry.event_name(),
-          tags: tags(),
-          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
-          description: description(),
-          unit: unit(),
-          reporter_options: reporter_options()
-        }
+  @type t() :: Counter.t() | LastValue.t() | Sum.t() | Summary.t() | Distribution.t()
 
   # API
 


### PR DESCRIPTION
Per @bryannaegele's suggestion.

The type can be used by reporters to specify that they accept a list of `Telemetry.Metrics.t()` as an input.