### PR TITLE
Missing measurement with unit conversion should not raise

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -737,6 +737,7 @@ defmodule Telemetry.Metrics do
       case measurements do
         %{^measurement => nil} -> nil
         %{^measurement => value} -> value * conversion_ratio
+        _ -> nil
       end
     end
   end

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -737,7 +737,7 @@ defmodule Telemetry.Metrics do
       case measurements do
         %{^measurement => nil} -> nil
         %{^measurement => value} -> value * conversion_ratio
-        _ -> nil
+        %{} -> nil
       end
     end
   end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -365,6 +365,16 @@ defmodule Telemetry.MetricsTest do
         assert metric.measurement.(%{latency: nil}) == nil
       end
 
+      test "does not raise when unit-conversion tuple is provided but measurement is missing" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "http.request.missing_measurement",
+            [unit: {:native, :millisecond}] ++ unquote(extra_options)
+          ])
+
+        assert metric.measurement.(%{}) == nil
+      end
+
       test "raises when unit-conversion tuple is provided but measurement is not a number" do
         metric =
           apply(Metrics, unquote(metric_type), [


### PR DESCRIPTION
50a76e2a5bf76f8ac08a308f725168063e4d2d4a introduced a bug where a missing measurement in combination with a unit conversion would cause an exception since there was no catch-all clause added.

This is affecting some production code. Please cut a release with this :)