### PR TITLE
Let counter take an additional option

### DIFF
--- a/lib/telemetry_metrics/console_reporter.ex
+++ b/lib/telemetry_metrics/console_reporter.ex
@@ -105,7 +105,7 @@ defmodule Telemetry.Metrics.ConsoleReporter do
                   Event dropped
                   """
 
-                metric.__struct__ == Telemetry.Metrics.Counter ->
+                metric.__struct__ == Telemetry.Metrics.Counter && not metric.count_by_measurement? ->
                   """
                   Tag values: #{inspect(tags)}
                   """

--- a/lib/telemetry_metrics/counter.ex
+++ b/lib/telemetry_metrics/counter.ex
@@ -14,7 +14,8 @@ defmodule Telemetry.Metrics.Counter do
     :keep,
     :description,
     :unit,
-    :reporter_options
+    :reporter_options,
+    {:count_by_measurement?, false}
   ]
 
   @type t :: %__MODULE__{
@@ -26,6 +27,7 @@ defmodule Telemetry.Metrics.Counter do
           keep: (:telemetry.event_metadata() -> boolean()),
           description: Metrics.description(),
           unit: Metrics.unit(),
-          reporter_options: Metrics.reporter_options()
+          reporter_options: Metrics.reporter_options(),
+          count_by_measurement?: boolean()
         }
 end

--- a/test/console_reporter_test.exs
+++ b/test/console_reporter_test.exs
@@ -8,6 +8,7 @@ defmodule Telemetry.Metrics.ConsoleReporterTest do
     metrics = [
       last_value("vm.memory.binary", unit: :byte),
       counter("vm.memory.total"),
+      counter("vm.memory.total", count_by_measurement?: true),
       summary("http.request.response_time",
         tag_values: fn
           %{foo: :bar} -> %{bar: :baz}
@@ -47,6 +48,10 @@ defmodule Telemetry.Metrics.ConsoleReporterTest do
            Metric measurement: :total (counter)
            Tag values: %{}
 
+           Metric measurement: :total (counter)
+           With value: 200
+           Tag values: %{}
+
            """
   end
 
@@ -63,6 +68,9 @@ defmodule Telemetry.Metrics.ConsoleReporterTest do
            Metric measurement: :binary (last_value)
            With value: :hundred byte (WARNING! measurement should be a number)
            Tag values: %{}
+
+           Metric measurement: :total (counter)
+           Measurement value missing (metric skipped)
 
            Metric measurement: :total (counter)
            Measurement value missing (metric skipped)

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -548,6 +548,12 @@ defmodule Telemetry.MetricsTest do
     end
   end
 
+  test "counter/2 raises if count_by_measurement? is not a boolean" do
+    assert_raise ArgumentError, fn ->
+      Metrics.counter("http.request.latency", count_by_measurement?: 1)
+    end
+  end
+
   defp converted_unit(measurement, from_unit, to_unit) do
     measurement * conversion_ratio(from_unit, to_unit)
   end


### PR DESCRIPTION
This additional option `:count_by_measurement?` will denote that the
measurement value should be used as the counting incrementer, rather
than just incrementing by 1.

Addresses: https://github.com/beam-telemetry/telemetry_metrics/issues/68