### PR TITLE
Fix deprecation warning on Elixir 1.11

### DIFF
--- a/lib/telemetry_metrics/console_reporter.ex
+++ b/lib/telemetry_metrics/console_reporter.ex
@@ -120,7 +120,7 @@ defmodule Telemetry.Metrics.ConsoleReporter do
               e ->
                 Logger.error([
                   "Could not format metric #{inspect(metric)}\n",
-                  Exception.format(:error, e, System.stacktrace())
+                  Exception.format(:error, e, __STACKTRACE__)
                 ])
 
                 """


### PR DESCRIPTION
Calls to `System.stacktrace()` have been deprecated in Elixir 1.11. `__STACKTRACE__` should be used instead ([reference](https://github.com/elixir-lang/elixir/blob/v1.11/CHANGELOG.md#4-hard-deprecations)).
After applying this patch, the library compiles fine without any warning.

Before:

    $mix compile --force --warnings-as-errors             
    Compiling 7 files (.ex)
    warning: System.stacktrace/0 is deprecated, use __STACKTRACE__ instead
      lib/telemetry_metrics/console_reporter.ex:123

    Compilation failed due to warnings while using the --warnings-as-errors option

After:

    $ mix compile --force --warnings-as-errors
    Compiling 7 files (.ex)
    Generated telemetry_metrics app