### PR TITLE
fix: Adds default value for dialyzer compliance

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -622,7 +622,7 @@ defmodule Telemetry.Metrics do
           "either the keep or drop option may be set, but not both"
   end
 
-  def keep_fun(nil, nil), do: nil
+  def keep_fun(nil, nil), do: fn _meta -> true end
   def keep_fun(nil, drop), do: fn meta -> not drop.(meta) end
   def keep_fun(keep, nil), do: keep
 


### PR DESCRIPTION
Lately, a strange dialyzer issue has arisen, and it is fixed by adding a reasonable default value for the keep function. Another option would be to change the typespec for `keep` in the library, but I figure this is the best way to make the code follow the specification while also keeping the API the same.