### PR TITLE
Extend measurement function to accept event metadata

### DIFF
--- a/lib/telemetry_metrics/console_reporter.ex
+++ b/lib/telemetry_metrics/console_reporter.ex
@@ -91,7 +91,7 @@ defmodule Telemetry.Metrics.ConsoleReporter do
         [
           header
           | try do
-              measurement = extract_measurement(metric, measurements)
+              measurement = extract_measurement(metric, measurements, metadata)
               tags = extract_tags(metric, metadata)
 
               cond do
@@ -136,8 +136,9 @@ defmodule Telemetry.Metrics.ConsoleReporter do
   defp keep?(%{keep: nil}, _metadata), do: true
   defp keep?(metric, metadata), do: metric.keep.(metadata)
 
-  defp extract_measurement(metric, measurements) do
+  defp extract_measurement(metric, measurements, metadata) do
     case metric.measurement do
+      fun when is_function(fun, 2) -> fun.(measurements, metadata)
       fun when is_function(fun, 1) -> fun.(measurements)
       key -> measurements[key]
     end

--- a/test/console_reporter_test.exs
+++ b/test/console_reporter_test.exs
@@ -133,7 +133,7 @@ defmodule Telemetry.Metrics.ConsoleReporterTest do
            """
   end
 
-  test "Can use metadata in the event measurement calculation", %{device: device} do
+  test "can use metadata in the event measurement calculation", %{device: device} do
     :telemetry.execute([:telemetry, :event_size], %{}, %{key: :value})
     {_in, out} = StringIO.contents(device)
 

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -487,6 +487,21 @@ defmodule Telemetry.MetricsTest do
         end
       end
 
+      test "converts a result of binary measurement function from one regular time unit to another" do
+        units = [:native, :second, :millisecond, :microsecond, :nanosecond]
+        measurement = :rand.uniform(10_000_000)
+
+        for from <- units, to <- units, from != to do
+          metric =
+            apply(Metrics, unquote(metric_type), [
+              "http.request.latency",
+              [unit: {from, to}, measurement: fn _measurements, _metadata -> measurement end]
+            ])
+
+          assert metric.measurement.(%{}, %{}) == converted_unit(measurement, from, to)
+        end
+      end
+
       test "converts a result of measurement function from one regular byte unit to another" do
         units = [
           {{:byte, 76_000_000}, {:kilobyte, 76_000}},

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -81,16 +81,15 @@ defmodule Telemetry.MetricsTest do
         unit = :second
         reporter_options = [sample_rate: 0.1]
 
-        options =
-          [
-            event_name: event_name,
-            measurement: measurement,
-            tags: tags,
-            tag_values: tag_values,
-            description: description,
-            unit: unit,
-            reporter_options: reporter_options
-          ]
+        options = [
+          event_name: event_name,
+          measurement: measurement,
+          tags: tags,
+          tag_values: tag_values,
+          description: description,
+          unit: unit,
+          reporter_options: reporter_options
+        ]
 
         metric = apply(Metrics, unquote(metric_type), [name, options])
 
@@ -229,7 +228,7 @@ defmodule Telemetry.MetricsTest do
         assert :value == metric.measurement
       end
 
-      test "setting function as measurement returns that function in metric spec" do
+      test "setting unary function as measurement returns that function in metric spec" do
         metric =
           apply(Metrics, unquote(metric_type), [
             [:my, :event],
@@ -240,6 +239,19 @@ defmodule Telemetry.MetricsTest do
         event_measurements = %{value: 3, other_value: 2}
 
         assert 42 == measurement_fun.(event_measurements)
+      end
+
+      test "setting binary function as measurement returns that function in metric spec" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            [:my, :event],
+            [measurement: fn _measurement, metadata -> length(metadata.messages) end]
+          ])
+
+        measurement_fun = metric.measurement
+        event_measurements = %{value: 3, other_value: 2}
+
+        assert 42 == measurement_fun.(event_measurements, %{messages: List.duplicate(true, 42)})
       end
 
       test "metric name can be a list of atoms" do

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -251,7 +251,7 @@ defmodule Telemetry.MetricsTest do
         measurement_fun = metric.measurement
         event_measurements = %{value: 3, other_value: 2}
 
-        assert 42 == measurement_fun.(event_measurements, %{messages: List.duplicate(true, 42)})
+        assert 42 == measurement_fun.(event_measurements, %{messages: List.duplicate("message", 42)})
       end
 
       test "metric name can be a list of atoms" do


### PR DESCRIPTION
If the measurement is a binary function, it will be passed the measurements and metadata maps. This will allow for tracking metrics in applications using the current Broadway metrics, for example.

Fixes https://github.com/dashbitco/broadway/issues/202