### PR TITLE
Fixing docs :event -> :event_name

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -196,7 +196,7 @@ defmodule Telemetry.Metrics do
 
       measurements = [
         {:process_info,
-         event: [:my_app, :worker],
+         event_name: [:my_app, :worker],
          name: MyApp.Worker,
          keys: [:message_queue_len, :memory]},
 
@@ -235,7 +235,7 @@ defmodule Telemetry.Metrics do
   ### Filtering on Metadata
 
   Let's assume you are using an HTTP client library in your application which has the following
-  event: `[:http_client, :request, :stop]`. You use this library in multiple places and
+  event_name: `[:http_client, :request, :stop]`. You use this library in multiple places and
   you'd like to monitor the request duration.
 
   You can use the event provided by the library but you have very different acceptable
@@ -247,13 +247,13 @@ defmodule Telemetry.Metrics do
 
       distribution(
         "http.client.request.duration",
-        event: [:http_client, :request, :stop],
+        event_name: [:http_client, :request, :stop],
         drop: &(match?(%{name: :fast_client}, &1))
       )
 
       distribution(
         "http.fast.client.request.duration",
-        event: [:http_client, :request, :stop],
+        event_name: [:http_client, :request, :stop],
         keep: &(match?(%{name: :fast_client}, &1))
       )
 

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -196,7 +196,7 @@ defmodule Telemetry.Metrics do
 
       measurements = [
         {:process_info,
-         event_name: [:my_app, :worker],
+         event: [:my_app, :worker],
          name: MyApp.Worker,
          keys: [:message_queue_len, :memory]},
 


### PR DESCRIPTION
Telemetry metrics structs have events specified by the :event_name atom as opposed to :event. Updating the docs to reflect that.