### PR TITLE
Add Emitter module for emitting metrics

### DIFF
--- a/lib/telemetry_metrics/emitter.ex
+++ b/lib/telemetry_metrics/emitter.ex
@@ -1,0 +1,161 @@
+defmodule Telemetry.Metrics.Emitter do
+  @moduledoc """
+  Emit metrics declared with `Telemetry.Metrics`.
+
+  Metric names are strings separated by `.`. Each name must have at least two
+  segments, the last being the measurement.
+
+  ### Examples
+
+  ```elixir
+  Emitter.increment("request.count")
+  ```
+  """
+
+  @doc """
+  Increment the value from the counter metric. The last segment of the metric is
+  the key to the measurement, while the value is always 1.
+
+  Define the metric using `TelemetryMetrics.counter/2`.
+  """
+  @spec increment(
+          counter :: String.t(),
+          metadata :: %{String.t() => String.t()} | %{atom() => String.t()}
+        ) :: :ok
+  def increment(counter, metadata \\ %{}) do
+    counter
+    |> split()
+    |> then(fn {metric, measurement} ->
+      :telemetry.execute(metric, %{measurement => 1}, metadata)
+    end)
+  end
+
+  @doc """
+  Emit the current value of the gauge as a number.
+
+  Define the metric using `TelemetrMetrics.last_value/2`.
+  """
+  @spec gauge(
+          metric :: String.t(),
+          value :: number(),
+          metadata :: %{String.t() => String.t()} | %{atom() => String.t()}
+        ) :: :ok
+  def gauge(metric, value, metadata \\ %{}) do
+    metric
+    |> split()
+    |> then(fn {metric, measurement} ->
+      :telemetry.execute(metric, %{measurement => value}, metadata)
+    end)
+  end
+
+  @doc """
+  Emit a measurement metric.
+
+  If an integer is given then emit the value using the final segment as the
+  measurement of the metric. In this case the return value is `:ok`.
+
+  If a function is given, measure the duration of the execution of the function.
+
+  In this latter case, the metric name must match in `prefix.stop.duration`
+   where `prefix` is any aribitrary metric name and the suffix `.stop.duration`
+  is required. The metric is reported as `prefix.stop` with a measurement of
+  `:duration`.
+
+  The result of `function.()` is returned.
+
+  Define the metric using `TelemetryMetrics.summary/2`.
+
+  ## Examples
+
+  Declaring the metric using `TelemetryMetrics.summary/2`:
+
+  ```elixir
+  TelemetryMetrics.summary("my.external.service.call.stop.duration", tags: [:operation])
+  ```
+
+  Emitting the metirc using `TelemetryMetrics.Emitter.measure/3`:
+
+  ```elixir
+  TelemetryMetrics.Emitter.measure("my.external.service.call.stop.duration", fn ->
+    MyExternalService.call(...)
+  end, %{operation: :record})
+
+  The metric will be `my.external.service.stop` with a measurement of
+  `duration: n` where `n` is the duration of the given function call.
+
+  Or when giving the measurement value itself:
+
+  ```elixir
+  TelemetryMetrics.summary("my.external.service.call.time", tags: [:operation])
+  ```
+
+  Emitting the metirc using `TelemetryMetrics.Emitter.measure/3`:
+
+  ```elixir
+  TelemetryMetrics.Emitter.measure("my.external.service.call.time", 100, %{operation: :record})
+  ```
+
+  The metric will be `my.external.service.call` with a measurement of `time:
+  100`.
+  """
+  @spec measure(
+          metric :: String.t(),
+          function_or_duration :: function() | integer(),
+          metadata :: %{String.t() => String.t()} | %{atom() => String.t()}
+        ) :: any()
+
+  def measure(metric, function_or_integer, metadata \\ %{})
+
+  def measure(metric, function, stop_metadata) when is_function(function) do
+    metric
+    |> stop_duration_split()
+    |> then(fn {prefix, [:stop, :duration]} ->
+      :telemetry.span(prefix, %{}, fn ->
+        {function.(), stop_metadata}
+      end)
+    end)
+  end
+
+  def measure(metric, duration, metadata) do
+    metric
+    |> split()
+    |> then(fn {metric, measurement} ->
+      :telemetry.execute(metric, %{measurement => duration}, metadata)
+    end)
+  end
+
+  defp split(metric) do
+    String.split(metric, ".")
+    |> Enum.map(&String.to_atom/1)
+    |> Enum.split(-1)
+    |> then(fn
+      {[], [_measurement]} ->
+        raise """
+        Metric names must have at least one segment separating the metric name from the measurement:
+        \t`metric_name.measurement` or `metric.name.measurement`, etc.
+
+        \t#{metric} has no segments.
+        """
+
+      {metric, [measurement]} ->
+        {metric, measurement}
+    end)
+  end
+
+  defp stop_duration_split(metric) do
+    String.split(metric, ".")
+    |> Enum.map(&String.to_atom/1)
+    |> Enum.split(-2)
+    |> then(fn
+      {prefix, [:stop, :duration]} ->
+        {prefix, [:stop, :duration]}
+
+      metric ->
+        raise """
+        Metrics given for measuring a function duration must end with ".stop.duration".
+
+        \t#{metric} is invalid.
+        """
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Telemetry.Metrics.MixProject do
       name: "Telemetry.Metrics",
       app: :telemetry_metrics,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       preferred_cli_env: preferred_cli_env(),
       deps: deps(),

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -1,5 +1,5 @@
 defmodule Telemetry.MetricsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   alias Telemetry.Metrics
 


### PR DESCRIPTION
Would something like this be of interest to the Telemetry Metrics package?

I'm very open to different interfaces, with my goal here being:
1. define functions that are more closely aligned to the metrics being manipulated
    - `increment` for counters, for example
2. use metric names that are more closely aligned with those defined by `Telemetry.Metrics`.
3. provide documentation on how `increment` is supported by the declaration of a counter metric, etc.

Generally, I find the `:telemetry.execute` function to be a bit inscrutable when emitting metrics.

I also find `:telemetry.span` nice but don't want to have to remember to define the return value tuple that has the metadata for the `.stop` metric.

Thank you for any interest and feedback.

I should also note that I bumped the required Elixir version since 1.12 is the only version still in support. I didn't bump the package version, however. I'm happy to move that back down and not use `then` in the PR.

---

This adds the `Telemetry.Metrics.Emitter` module as a higher level
interface over `:telemetry.execute` and `:telemetry.span`.

The functions defined attempt to mirror those in `Telemetry.Metrics`,
using the same metric names with documentation describing how the two
relate.