### PR TITLE
Fix tag example with duration instead of count

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -99,10 +99,10 @@ defmodule Telemetry.Metrics do
   fetched from event metadata - this means that in this example, `[:db, :query]` events
   need to include `:table` and `:operation` keys in their payload:
 
-      :telemetry.execute([:db, :query], %{count: 1}, %{table: "users", operation: "insert"})
-      :telemetry.execute([:db, :query], %{count: 1}, %{table: "users", operation: "select"})
-      :telemetry.execute([:db, :query], %{count: 1}, %{table: "sessions", operation: "insert"})
-      :telemetry.execute([:db, :query], %{count: 1}, %{table: "sessions", operation: "insert"})
+      :telemetry.execute([:db, :query], %{duration: 198}, %{table: "users", operation: "insert"})
+      :telemetry.execute([:db, :query], %{duration: 112}, %{table: "users", operation: "select"})
+      :telemetry.execute([:db, :query], %{duration: 201}, %{table: "sessions", operation: "insert"})
+      :telemetry.execute([:db, :query], %{duration: 212}, %{table: "sessions", operation: "insert"})
 
   The result of aggregating the events above looks like this:
 

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -92,7 +92,7 @@ defmodule Telemetry.Metrics do
 
   This is where tagging comes into play. All metric definitions accept a `:tags` option:
 
-      counter("db.query.count", tags: [:table, :operation])
+      counter("db.query.duration", tags: [:table, :operation])
 
   The above definition means that we want to keep track of the number of queries, but
   we want a separate counter for each unique pair of table and operation. Tag values are

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -99,10 +99,10 @@ defmodule Telemetry.Metrics do
   fetched from event metadata - this means that in this example, `[:db, :query]` events
   need to include `:table` and `:operation` keys in their payload:
 
-      :telemetry.execute([:db, :query], %{duration: 198}, %{table: "users", operation: "insert"})
-      :telemetry.execute([:db, :query], %{duration: 112}, %{table: "users", operation: "select"})
-      :telemetry.execute([:db, :query], %{duration: 201}, %{table: "sessions", operation: "insert"})
-      :telemetry.execute([:db, :query], %{duration: 212}, %{table: "sessions", operation: "insert"})
+      :telemetry.execute([:db, :query], %{count: 1}, %{table: "users", operation: "insert"})
+      :telemetry.execute([:db, :query], %{count: 1}, %{table: "users", operation: "select"})
+      :telemetry.execute([:db, :query], %{count: 1}, %{table: "sessions", operation: "insert"})
+      :telemetry.execute([:db, :query], %{count: 1}, %{table: "sessions", operation: "insert"})
 
   The result of aggregating the events above looks like this:
 


### PR DESCRIPTION
The metric is declared as a `counter` with a `.count` suffix, while the
example usage used a `duration` measurement. This should be a `count`
measurement.