### PR TITLE
Make keep_fun/2 private

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -629,9 +629,9 @@ defmodule Telemetry.Metrics do
           "either the keep or drop option may be set, but not both"
   end
 
-  def keep_fun(nil, nil), do: nil
-  def keep_fun(nil, drop), do: fn meta -> not drop.(meta) end
-  def keep_fun(keep, nil), do: keep
+  defp keep_fun(nil, nil), do: nil
+  defp keep_fun(nil, drop), do: fn meta -> not drop.(meta) end
+  defp keep_fun(keep, nil), do: keep
 
   @spec fill_in_default_metric_options([metric_option()]) :: [metric_option()]
   defp fill_in_default_metric_options(options) do


### PR DESCRIPTION
Seems that keep_fun is only intended to be used internally and is undocumented. Therefore it's better defined as a private function