### PR TITLE
Make validate_recording_rule_fun_options!/2 private

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -622,9 +622,9 @@ defmodule Telemetry.Metrics do
           "expected recording rule to be a function accepting metadata, got #{inspect(term)}"
   end
 
-  def validate_recording_rule_fun_options!(keep, drop) when is_nil(keep) or is_nil(drop), do: :ok
+  defp validate_recording_rule_fun_options!(keep, drop) when is_nil(keep) or is_nil(drop), do: :ok
 
-  def validate_recording_rule_fun_options!(_keep, _drop) do
+  defp validate_recording_rule_fun_options!(_keep, _drop) do
     raise ArgumentError,
           "either the keep or drop option may be set, but not both"
   end


### PR DESCRIPTION
Seems that validate_recording_rule_fun_options!/2 is only intended to be used internally and is undocumented. Therefore it's better defined as a private function.

Unfortunately https://github.com/beam-telemetry/telemetry_metrics/pull/102 was merged before I noticed this second function. You folks are just too fast for me ;) 