### PR TITLE
Use function capture for attaching `handle_event/4`

### DIFF
--- a/lib/telemetry_metrics/console_reporter.ex
+++ b/lib/telemetry_metrics/console_reporter.ex
@@ -57,7 +57,7 @@ defmodule Telemetry.Metrics.ConsoleReporter do
 
     for {event, metrics} <- groups do
       id = {__MODULE__, event, self()}
-      :telemetry.attach(id, event, &handle_event/4, {metrics, device})
+      :telemetry.attach(id, event, &__MODULE__.handle_event/4, {metrics, device})
     end
 
     {:ok, Map.keys(groups)}
@@ -72,7 +72,7 @@ defmodule Telemetry.Metrics.ConsoleReporter do
     :ok
   end
 
-  defp handle_event(event_name, measurements, metadata, {metrics, device}) do
+  def handle_event(event_name, measurements, metadata, {metrics, device}) do
     prelude = """
     [#{inspect(__MODULE__)}] Got new event!
     Event name: #{Enum.join(event_name, ".")}


### PR DESCRIPTION
I hope you don't mind me making a PR without an associated issue. I couldn't find an existing one and this seemed like a relatively easy fix.

The documentation for `:telemetry.attach/4` states that function capture should be used for the event handler, rather than local function capture for performance reasons. Using local function capture also leads to warnings like:

```
https://hexdocs.pm/telemetry/telemetry.html#attach/4
[info] The function passed as a handler with ID {Telemetry.Metrics.ConsoleReporter, [:phoenix, :router_dispatch, :start], #PID<0.576.0>} is a local function.
This means that it is either an anonymous function or a capture of a function without a module specified. That may cause a performance penalty when calling that handler. For more details see the note in `telemetry:attach/4` documentation.
```

Unfortunately, to allow using function capture, I've had to make `handle_event/4` a public function.