### PR TITLE
Implement event filtering on measurements (#77)

### DIFF
--- a/lib/telemetry_metrics/console_reporter.ex
+++ b/lib/telemetry_metrics/console_reporter.ex
@@ -100,7 +100,7 @@ defmodule Telemetry.Metrics.ConsoleReporter do
                   Measurement value missing (metric skipped)
                   """
 
-                not keep?(metric, metadata) ->
+                not keep?(metric, metadata, measurements) ->
                   """
                   Event dropped
                   """
@@ -142,8 +142,13 @@ defmodule Telemetry.Metrics.ConsoleReporter do
     "#{inspect(measurement)} [via #{inspect(fun)}]"
   end
 
-  defp keep?(%{keep: nil}, _metadata), do: true
-  defp keep?(metric, metadata), do: metric.keep.(metadata)
+  defp keep?(metric, metadata, measurements) do
+    case metric do
+      %{keep: nil} -> true
+      %{keep: keep} when is_function(keep, 1) -> keep.(metadata)
+      %{keep: keep} when is_function(keep, 2) -> keep.(metadata, measurements)
+    end
+  end
 
   defp extract_measurement(metric, measurements, metadata) do
     case metric.measurement do

--- a/lib/telemetry_metrics/counter.ex
+++ b/lib/telemetry_metrics/counter.ex
@@ -22,8 +22,8 @@ defmodule Telemetry.Metrics.Counter do
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
           tags: Metrics.tags(),
-          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
-          keep: (:telemetry.event_metadata() -> boolean()),
+          tag_values: Metrics.tag_values(),
+          keep: Metrics.keep(),
           description: Metrics.description(),
           unit: Metrics.unit(),
           reporter_options: Metrics.reporter_options()

--- a/lib/telemetry_metrics/distribution.ex
+++ b/lib/telemetry_metrics/distribution.ex
@@ -22,8 +22,8 @@ defmodule Telemetry.Metrics.Distribution do
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
           tags: Metrics.tags(),
-          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
-          keep: (:telemetry.event_metadata() -> boolean()),
+          tag_values: Metrics.tag_values(),
+          keep: Metrics.keep(),
           description: Metrics.description(),
           unit: Metrics.unit(),
           reporter_options: Metrics.reporter_options()

--- a/lib/telemetry_metrics/last_value.ex
+++ b/lib/telemetry_metrics/last_value.ex
@@ -22,8 +22,8 @@ defmodule Telemetry.Metrics.LastValue do
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
           tags: Metrics.tags(),
-          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
-          keep: (:telemetry.event_metadata() -> boolean()),
+          tag_values: Metrics.tag_values(),
+          keep: Metrics.keep(),
           description: Metrics.description(),
           unit: Metrics.unit(),
           reporter_options: Metrics.reporter_options()

--- a/lib/telemetry_metrics/sum.ex
+++ b/lib/telemetry_metrics/sum.ex
@@ -22,8 +22,8 @@ defmodule Telemetry.Metrics.Sum do
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
           tags: Metrics.tags(),
-          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
-          keep: (:telemetry.event_metadata() -> boolean()),
+          tag_values: Metrics.tag_values(),
+          keep: Metrics.keep(),
           description: Metrics.description(),
           unit: Metrics.unit(),
           reporter_options: Metrics.reporter_options()

--- a/lib/telemetry_metrics/summary.ex
+++ b/lib/telemetry_metrics/summary.ex
@@ -22,8 +22,8 @@ defmodule Telemetry.Metrics.Summary do
           event_name: :telemetry.event_name(),
           measurement: Metrics.measurement(),
           tags: Metrics.tags(),
-          tag_values: (:telemetry.event_metadata() -> :telemetry.event_metadata()),
-          keep: (:telemetry.event_metadata() -> boolean()),
+          tag_values: Metrics.tag_values(),
+          keep: Metrics.keep(),
           description: Metrics.description(),
           unit: Metrics.unit(),
           reporter_options: Metrics.reporter_options()


### PR DESCRIPTION
This enables us to filter events based on measurement values as requested in #77. Let me know if I should tweak documentation language, add more tests, or change the implementation.

As noted in that issue, this isn't a breaking change for the API of any of the `Telemetry.Metrics.*` structs, but 3rd-party reporters might need to be updated to support the new 2-arity version of `:keep`/`:drop`.