### PR TITLE
Fix incorrect measurement callback argument in `ConsoleReporter`

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -412,7 +412,7 @@ defmodule Telemetry.Metrics do
   @type tag_values :: (:telemetry.event_metadata() -> :telemetry.event_metadata())
   @type predicate_fun ::
           (:telemetry.event_metadata() -> boolean())
-          | (:telemetry.event_metadata(), :telemetry.event_measurements() -> boolean())
+          | (:telemetry.event_metadata(), :telemetry.event_value() -> boolean())
   @type keep :: predicate_fun()
   @type drop :: predicate_fun()
   @type description :: nil | String.t()
@@ -623,7 +623,7 @@ defmodule Telemetry.Metrics do
 
   defp validate_recording_rule_fun!(term) do
     raise ArgumentError,
-          "expected recording rule to be a function accepting either metadata or metadata and measurements, got #{inspect(term)}"
+          "expected recording rule to be a function accepting either metadata or metadata and measurement, got #{inspect(term)}"
   end
 
   defp validate_recording_rule_fun_options!(keep, drop) when is_nil(keep) or is_nil(drop), do: :ok

--- a/lib/telemetry_metrics/console_reporter.ex
+++ b/lib/telemetry_metrics/console_reporter.ex
@@ -100,7 +100,7 @@ defmodule Telemetry.Metrics.ConsoleReporter do
                   Measurement value missing (metric skipped)
                   """
 
-                not keep?(metric, metadata, measurements) ->
+                not keep?(metric, metadata, measurement) ->
                   """
                   Event dropped
                   """
@@ -142,11 +142,11 @@ defmodule Telemetry.Metrics.ConsoleReporter do
     "#{inspect(measurement)} [via #{inspect(fun)}]"
   end
 
-  defp keep?(metric, metadata, measurements) do
+  defp keep?(metric, metadata, measurement) do
     case metric do
       %{keep: nil} -> true
       %{keep: keep} when is_function(keep, 1) -> keep.(metadata)
-      %{keep: keep} when is_function(keep, 2) -> keep.(metadata, measurements)
+      %{keep: keep} when is_function(keep, 2) -> keep.(metadata, measurement)
     end
   end
 


### PR DESCRIPTION
Upon re-reading #77, I'm pretty sure that I implemented the measurement filtering functionality in `Telemetry.Metrics.ConsoleReporter` incorrectly by including the entire measurements map instead of just the measurement for the current metric. The typespec for `keep` and `drop` aligned with this implementation, but this test did not:

https://github.com/beam-telemetry/telemetry_metrics/blob/74d186ed3d40dd441513f1b743025495f741a337/test/telemetry_metrics_test.exs#L165-L174

There was never a test for the reporter implementation, which is why this discrepancy wasn't caught. This makes it so that the `keep`/`drop` functions accept only the measurement value specified for the metric.