### PR TITLE
Use public function instead of lambda

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -647,7 +647,7 @@ defmodule Telemetry.Metrics do
   defp default_metric_options() do
     [
       tags: [],
-      tag_values: & &1,
+      tag_values: &Function.identity/1,
       nil: nil,
       description: nil,
       reporter_options: []


### PR DESCRIPTION
Metrics specifications can be copied to many different processes by some of the handlers, this mean that we need to reduce the size of metrics specs as much as possible to perform well in high throughput services.

This change replaces lambda with function capture, that not only provides smaller footprint, it also allows some handlers to pattern match on function if needed.
