### PR TITLE
Align documentation/tests with typespecs for `:keep` and `:drop`

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -68,12 +68,12 @@ defmodule Telemetry.Metrics do
     * `:tag_values` - a function that receives the metadata and returns a map with
       the tags as keys and their respective values. Defaults to returning the
       metadata itself.
-    * `:keep` - a predicate function that evaluates the metadata and measurement
-      to conditionally record a given event. `:keep` and `:drop` cannot be
-      combined. Defaults to `nil`.
-    * `:drop` - a predicate function that evaluates the metadata and measurement
-      to conditionally skip recording a given event. `:keep` and `:drop` cannot
-      be combined. Defaults to `nil`.
+    * `:keep` - a predicate function that evaluates the metadata and
+      measurements to conditionally record a given event. `:keep` and `:drop`
+      cannot be combined. Defaults to `nil`.
+    * `:drop` - a predicate function that evaluates the metadata and
+      measurements to conditionally skip recording a given event. `:keep` and
+      `:drop` cannot be combined. Defaults to `nil`.
     * `:description` - human-readable description of the metric. Might be used by
       reporters for documentation purposes. Defaults to `nil`.
     * `:unit` - an atom describing the unit of selected measurement, typically in

--- a/test/console_reporter_test.exs
+++ b/test/console_reporter_test.exs
@@ -25,6 +25,9 @@ defmodule Telemetry.Metrics.ConsoleReporterTest do
           metadata[:boom] == :pow
         end
       ),
+      summary("parser.result.size",
+        keep: fn _metadata, %{size: size} -> size > 1024 end
+      ),
       sum("telemetry.event_size.metadata",
         measurement: &__MODULE__.metadata_measurement/2
       ),
@@ -110,7 +113,7 @@ defmodule Telemetry.Metrics.ConsoleReporterTest do
            """
   end
 
-  test "filters events", %{device: device} do
+  test "filters events on metadata", %{device: device} do
     :telemetry.execute([:http, :request], %{response_time: 1000}, %{foo: :bar, boom: :pow})
     {_in, out} = StringIO.contents(device)
 
@@ -122,6 +125,32 @@ defmodule Telemetry.Metrics.ConsoleReporterTest do
 
            Metric measurement: :response_time (summary)
            Event dropped
+
+           """
+  end
+
+  test "filters events on measurement", %{device: device} do
+    :telemetry.execute([:parser, :result], %{size: 512})
+    :telemetry.execute([:parser, :result], %{size: 2048})
+    {_in, out} = StringIO.contents(device)
+
+    assert out == """
+           [Telemetry.Metrics.ConsoleReporter] Got new event!
+           Event name: parser.result
+           All measurements: %{size: 512}
+           All metadata: %{}
+
+           Metric measurement: :size (summary)
+           Event dropped
+
+           [Telemetry.Metrics.ConsoleReporter] Got new event!
+           Event name: parser.result
+           All measurements: %{size: 2048}
+           All metadata: %{}
+
+           Metric measurement: :size (summary)
+           With value: 2048
+           Tag values: %{}
 
            """
   end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -166,11 +166,11 @@ defmodule Telemetry.MetricsTest do
         metric =
           apply(Metrics, unquote(metric_type), [
             "my.repo.query",
-            [keep: &(match?(%{repo: :my_app_read_only_repo}, &1) and &2 > 100)]
+            [keep: &(match?(%{repo: :my_app_read_only_repo}, &1) and &2.duration > 100)]
           ])
 
-        assert metric.keep.(%{repo: :my_app_read_only_repo}, 200)
-        refute metric.keep.(%{repo: :my_app_read_only_repo}, 50)
+        assert metric.keep.(%{repo: :my_app_read_only_repo}, %{duration: 200})
+        refute metric.keep.(%{repo: :my_app_read_only_repo}, %{duration: 50})
       end
 
       test "setting both keep and drop options raises" do


### PR DESCRIPTION
The documentation and tests for the `:keep` and `:drop` metric options incorrectly suggested that the optional 2nd argument for both options (introduced in 3fde830) were a single `measurement` value instead of a `measurements` map.

See #118