### PR TITLE
Specialise validation for metric and event_name

### DIFF
--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -299,11 +299,13 @@ defmodule Telemetry.MetricsTest do
       end
 
       test "raises when event name derived from metric name is empty" do
-        assert_raise ArgumentError, fn ->
-          apply(Metrics, unquote(metric_type), [
-            "latency"
-          ])
-        end
+        assert_raise ArgumentError,
+                     "event_name can't be empty (metric must be namespaced or :event_name explicitly set)",
+                     fn ->
+                       apply(Metrics, unquote(metric_type), [
+                         "latency"
+                       ])
+                     end
       end
 
       test "raises when event name is empty" do


### PR DESCRIPTION
Trying to address https://github.com/beam-telemetry/telemetry_metrics/issues/124

I was unsure how to address this and I opted for "specialising" the error message/validation base on what's being validated

This will "break" error messages in a sense, but it hopefully makes clearer what's not working (metric or event_name) and why

Happy to change the approach if it doesn't make sense