### PR TITLE
Allow atom `:all` as `:tags` option

### DIFF
--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -408,7 +408,7 @@ defmodule Telemetry.Metrics do
           | (:telemetry.event_measurements() -> number())
           | (:telemetry.event_measurements(), :telemetry.event_metadata() -> number())
   @type tag :: term()
-  @type tags :: [tag()]
+  @type tags :: [tag()] | :all
   @type tag_values :: (:telemetry.event_metadata() -> :telemetry.event_metadata())
   @type predicate_fun ::
           (:telemetry.event_metadata() -> boolean())
@@ -672,6 +672,8 @@ defmodule Telemetry.Metrics do
   end
 
   @spec validate_tags!(term()) :: :ok | no_return()
+  defp validate_tags!(:all), do: :ok
+
   defp validate_tags!(list) when is_list(list) do
     :ok
   end

--- a/test/telemetry_metrics_test.exs
+++ b/test/telemetry_metrics_test.exs
@@ -129,6 +129,16 @@ defmodule Telemetry.MetricsTest do
         assert event_metadata == tag_values_fun.(event_metadata)
       end
 
+      test "tags can use atom `:all` to mark that all metadata should be used" do
+        metric =
+          apply(Metrics, unquote(metric_type), [
+            "my.event.value",
+            [tags: :all]
+          ])
+
+        assert :all == metric.tags
+      end
+
       test "setting function as tag_values returns that function in metric spec" do
         metric =
           apply(Metrics, unquote(metric_type), [


### PR DESCRIPTION
This is meant for collectors to just use metadata as a whole. The reasoning for that is that in many cases user may know, that all provided metadata will be relevant (especially true for metrics of the current application). Currently the way to extract relevant metrics is to use `Map.take/2`, but that can introduce unwanted slowdown due to requirement of constructing new map even if all keys are selected.

In my benchmarking of my project `Map.take/2` (internal `Map.take/3` function to be exact) was responsible for 7.83% of the whole runtime (very tight loop), and I simply take whole metadata into account, so that additional processing is not needed.