### PR TITLE
Fix Elixir 1.20 unused require warnings

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.20.0-rc.6
+erlang 27.3.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.20.0-rc.6
-erlang 27.3.3

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -393,7 +393,6 @@ defmodule Telemetry.Metrics do
       end
   """
 
-  require Logger
 
   alias Telemetry.Metrics.{Counter, Sum, LastValue, Summary, Distribution}
 

--- a/lib/telemetry_metrics.ex
+++ b/lib/telemetry_metrics.ex
@@ -393,7 +393,6 @@ defmodule Telemetry.Metrics do
       end
   """
 
-
   alias Telemetry.Metrics.{Counter, Sum, LastValue, Summary, Distribution}
 
   @typedoc """


### PR DESCRIPTION
Remove unused `require Logger` statement to resolve Elixir 1.20 compilation warnings.